### PR TITLE
explicitly call future.batchtools

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,11 +3,15 @@ Title: Doubly-Robust Nonparametric Estimation and Inference
 Version: 1.0.2
 Authors@R: c(
     person("David", "Benkeser", email = "benkeser@emory.edu",
-           role = c("aut", "cre","cph")),
-    person("Nima", "Hejazi", email = "nhejazi@berkeley.edu", role = "ctb"))
+           role = c("aut", "cre","cph"),
+           comment = c(ORCID = "0000-0002-1019-8343")),
+    person("Nima", "Hejazi", email = "nhejazi@berkeley.edu",
+           role = "ctb",
+           comment = c(ORCID = "0000-0002-7127-2789")))
 Description: Targeted minimum loss-based estimators of counterfactual means and
     causal effects that are doubly-robust with respect both to consistency and
-    asymptotic normality (Benkeser et al (2017), <doi:10.1093/biomet/asx053>; MJ van der Laan (2014), <doi:10.1515/ijb-2012-0038>).
+    asymptotic normality (Benkeser et al (2017), <doi:10.1093/biomet/asx053>; MJ
+    van der Laan (2014), <doi:10.1515/ijb-2012-0038>).
 Depends:
     R (>= 3.2.0)
 Imports:

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,27 @@
 md:
-	r -e "rmarkdown::render('README.Rmd')"
+	    Rscript -e "rmarkdown::render('README.Rmd', output_file = 'README.md')"
 
 site:
-	r -e "pkgdown::build_site()"
+	    Rscript -e "pkgdown::build_site()"
+
+fastcheck:
+	    Rscript -e "devtools::check(build_args = '--no-build-vignettes')"
 
 check:
-	r -e "devtools::check()"
+	    Rscript -e "devtools::check()"
 
 test:
-	r -e "devtools::test()"
+	    Rscript -e "devtools::test()"
 
 doc:
-	r -e "devtools::document()"
+	    Rscript -e "devtools::document()"
 
 cov:
 	r -e "covr::package_coverage(type = 'all', combine_types = FALSE, line_exclusions = list('R/plots.R', 'R/printing.R', 'R/utils.R'))"
+
+build:
+	    Rscript -e "devtools::build()"
+
+style:
+	Rscript -e "styler::style_pkg()"
+

--- a/R/confint.R
+++ b/R/confint.R
@@ -1,41 +1,41 @@
 #' Compute confidence intervals for drtmle and adaptive_iptw@
 #' @param ... Arguments to be passed to method
 #' @export
-ci <- function(...){
+ci <- function(...) {
   UseMethod("ci")
 }
 
 #' Confidence intervals for drtmle objects
-#' 
+#'
 #' @param object An object of class \code{"drtmle"}
-#' @param est A vector indicating for which estimators to return a 
+#' @param est A vector indicating for which estimators to return a
 #' confidence interval. Possible estimators include the TMLE with doubly robust
-#' inference (\code{"drtmle"}, recommended), the AIPTW with additional correction 
-#' for misspecification (\code{"aiptw_c"}, not recommended), the standard TMLE 
-#' (\code{"tmle"}, recommended only for comparison to "drtmle"), the standard 
-#' AIPTW (\code{"aiptw"}, recommended only for comparison to "drtmle"), and 
-#' G-computation (\code{"gcomp"}, not recommended).  
+#' inference (\code{"drtmle"}, recommended), the AIPTW with additional correction
+#' for misspecification (\code{"aiptw_c"}, not recommended), the standard TMLE
+#' (\code{"tmle"}, recommended only for comparison to "drtmle"), the standard
+#' AIPTW (\code{"aiptw"}, recommended only for comparison to "drtmle"), and
+#' G-computation (\code{"gcomp"}, not recommended).
 #' @param level The nominal coverage probability of the desired confidence interval (should be
-#' between 0 and 1). Default computes 95\% confidence intervals. 
+#' between 0 and 1). Default computes 95\% confidence intervals.
 #' @param contrast Specifies the parameter for which to return confidence intervals.
 #' If \code{contrast=NULL}, then confidence intervals for the
 #' marginal means are computed. If instead, \code{contrast} is a numeric vector of ones, negative ones,
 #' and zeros to define linear combinations of the various means (e.g., to estimate an average
 #' treatment effect, see example). Finally, \code{contrast} can be a list with named functions
 #' \code{f}, \code{f_inv}, \code{h}, and \code{fh_grad}. The first two functions should take
-#' as input argument \code{eff}. Respectively, these specify which transformation 
+#' as input argument \code{eff}. Respectively, these specify which transformation
 #' of the effect measure to compute the confidence interval for and the inverse
 #' transformation to put the confidence interval back on the original scale. The function \code{h}
 #' defines the contrast to be estimated and should take as input \code{est}, a vector
 #' of the same length as \code{object$a_0}, and output the desired contrast. The function
-#' \code{fh_grad} is the gradient of the function \code{h}. See examples and vignette for more information. 
+#' \code{fh_grad} is the gradient of the function \code{h}. See examples and vignette for more information.
 #' @param ... Other options (not currently used).
 #' @importFrom stats qnorm
 #' @export
 #' @method ci drtmle
 #' @return An object of class \code{"ci.drtmle"} with point estimates and
-#' confidence intervals of the specified level. 
-#' 
+#' confidence intervals of the specified level.
+#'
 #' @examples
 #' # load super learner
 #' library(SuperLearner)
@@ -53,13 +53,13 @@ ci <- function(...){
 #'             SL_g=c("SL.glm","SL.mean"),
 #'             SL_Qr="SL.npreg",
 #'             SL_gr="SL.npreg", maxIter = 1)
-#' 
+#'
 #' # get confidence intervals for each mean
 #' ci_mean <- ci(fit1)
-#' 
+#'
 #' # get confidence intervals for ATE
 #' ci_ATE <- ci(fit1, contrast = c(1,-1))
-#' 
+#'
 #' # get confidence intervals for risk ratio by
 #' # computing CI on log scale and back-transforming
 #' myContrast <- list(f = function(eff){ log(eff) },
@@ -70,114 +70,117 @@ ci <- function(...){
 
 
 ci.drtmle <- function(object, est = c("drtmle"), level = 0.95,
-                      contrast = NULL,...){
-	if(class(object) != "drtmle"){
-		stop("ci only works with drtmle objects")
-	}
-	out <- vector(mode = "list", length = length(est))
-	names(out) <- est
-	# if no contrast then return an CI for each 
-	# covariate-adjusted mean
-	if(is.null(contrast)){
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = length(object$a_0), ncol = 3)
-			for(j in seq_along(object$a_0)){
-				out[[i]][j,] <-
-				  rep(object[[est[i]]]$est[j],3) + stats::qnorm(c(0.5,(1-level)/2,(1+level)/2))*
-				  	rep(sqrt(object[[est[i]]]$cov[j,j]),3)
-			}
-			row.names(out[[i]]) <- object$a_0
-			colnames(out[[i]]) <- c("est","cil","ciu")
-		}
-	}else if(is.numeric(contrast)){
-		# check that contrast came in correctly
-		if(length(contrast) != length(object$a_0)){
-			stop("length of contrast vector not equal to length of a_0")
-		}
-		if(!all(contrast %in% c(-1,1,0))){
-			stop("contrast should only be -1, 1, or 0")
-		}
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = 1, ncol = 3)
-			g <- matrix(contrast, nrow = length(contrast))
-			p <- matrix(object[[est[i]]]$est, nrow = length(contrast))
-			v <- object[[est[i]]]$cov
-			thisC <- t(g)%*%p
-			thisSe <- sqrt(t(g)%*%v%*%g)
-			out[[i]][1,] <- rep(thisC,3) + stats::qnorm(c(0.5,(1-level)/2,(1+level)/2))*
-				rep(thisSe,3)
-			# E[Y(a_0[1])] - E[Y(a_0[2])]
-			indMinus <- which(contrast == -1)
-			indPlus <- which(contrast == 1)
-			plusTerms <- minusTerms <- ""
-			if(length(indMinus) > 0){
-				minusTerms <- paste0("E[Y(",object$a_0[indMinus],")]")
-			}
-			if(length(indPlus) > 0){
-				plusTerms <- paste0("E[Y(",object$a_0[indPlus],")]")
-			}
-			thisName <- paste0(paste0(plusTerms,collapse = "+"),
-			                   ifelse(length(indMinus)>0,"-",""),
-			                   paste0(minusTerms,collapse="-"))
+                      contrast = NULL, ...) {
+  if (class(object) != "drtmle") {
+    stop("ci only works with drtmle objects")
+  }
+  out <- vector(mode = "list", length = length(est))
+  names(out) <- est
+  # if no contrast then return an CI for each
+  # covariate-adjusted mean
+  if (is.null(contrast)) {
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = length(object$a_0), ncol = 3)
+      for (j in seq_along(object$a_0)) {
+        out[[i]][j, ] <-
+          rep(object[[est[i]]]$est[j], 3) + stats::qnorm(c(0.5, (1 - level) / 2, (1 + level) / 2)) *
+            rep(sqrt(object[[est[i]]]$cov[j, j]), 3)
+      }
+      row.names(out[[i]]) <- object$a_0
+      colnames(out[[i]]) <- c("est", "cil", "ciu")
+    }
+  } else if (is.numeric(contrast)) {
+    # check that contrast came in correctly
+    if (length(contrast) != length(object$a_0)) {
+      stop("length of contrast vector not equal to length of a_0")
+    }
+    if (!all(contrast %in% c(-1, 1, 0))) {
+      stop("contrast should only be -1, 1, or 0")
+    }
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = 1, ncol = 3)
+      g <- matrix(contrast, nrow = length(contrast))
+      p <- matrix(object[[est[i]]]$est, nrow = length(contrast))
+      v <- object[[est[i]]]$cov
+      thisC <- t(g) %*% p
+      thisSe <- sqrt(t(g) %*% v %*% g)
+      out[[i]][1, ] <- rep(thisC, 3) + stats::qnorm(c(0.5, (1 - level) / 2, (1 + level) / 2)) *
+        rep(thisSe, 3)
+      # E[Y(a_0[1])] - E[Y(a_0[2])]
+      indMinus <- which(contrast == -1)
+      indPlus <- which(contrast == 1)
+      plusTerms <- minusTerms <- ""
+      if (length(indMinus) > 0) {
+        minusTerms <- paste0("E[Y(", object$a_0[indMinus], ")]")
+      }
+      if (length(indPlus) > 0) {
+        plusTerms <- paste0("E[Y(", object$a_0[indPlus], ")]")
+      }
+      thisName <- paste0(
+        paste0(plusTerms, collapse = "+"),
+        ifelse(length(indMinus) > 0, "-", ""),
+        paste0(minusTerms, collapse = "-")
+      )
 
-			row.names(out[[i]]) <- thisName
-			colnames(out[[i]]) <- c("est","cil","ciu")
-		}
-	}else if(is.list(contrast)){
-		if(!all(c("f","f_inv","h","fh_grad") %in% names(contrast))){
-			stop("some function missing in contrast. see ?ci.drtmle for help.")
-		}
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = 1, ncol = 3)
-			thisC <- do.call(contrast$h,args=list(est = object[[est[i]]]$est))
-			f_thisC <- do.call(contrast$f,args=list(eff = thisC))
+      row.names(out[[i]]) <- thisName
+      colnames(out[[i]]) <- c("est", "cil", "ciu")
+    }
+  } else if (is.list(contrast)) {
+    if (!all(c("f", "f_inv", "h", "fh_grad") %in% names(contrast))) {
+      stop("some function missing in contrast. see ?ci.drtmle for help.")
+    }
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = 1, ncol = 3)
+      thisC <- do.call(contrast$h, args = list(est = object[[est[i]]]$est))
+      f_thisC <- do.call(contrast$f, args = list(eff = thisC))
 
-			grad <- matrix(do.call(contrast$fh_grad,
-			                       args=list(est = object[[est[i]]]$est)
-			               ),nrow = length(object$a_0))
-			v <- object[[est[i]]]$cov
-			thisSe <- sqrt(t(grad)%*%v%*%grad)
-			transformCI <- rep(f_thisC,3) + stats::qnorm(c(0.5,(1-level)/2,(1+level)/2))*
-				rep(thisSe,3)
-			out[[i]][1,] <- do.call(contrast$f_inv, args = list(eff = transformCI))
-			row.names(out[[i]]) <- c("user contrast")
-			colnames(out[[i]]) <- c("est","cil","ciu")
-		}
-	}
-	class(out) <- "ci.drtmle"
-	return(out)
+      grad <- matrix(do.call(
+        contrast$fh_grad,
+        args = list(est = object[[est[i]]]$est)
+      ), nrow = length(object$a_0))
+      v <- object[[est[i]]]$cov
+      thisSe <- sqrt(t(grad) %*% v %*% grad)
+      transformCI <- rep(f_thisC, 3) + stats::qnorm(c(0.5, (1 - level) / 2, (1 + level) / 2)) *
+        rep(thisSe, 3)
+      out[[i]][1, ] <- do.call(contrast$f_inv, args = list(eff = transformCI))
+      row.names(out[[i]]) <- c("user contrast")
+      colnames(out[[i]]) <- c("est", "cil", "ciu")
+    }
+  }
+  class(out) <- "ci.drtmle"
+  return(out)
 }
 
 #' Confidence intervals for adaptive_iptw objects
-#' 
+#'
 #' Estimate confidence intervals for objects of class \code{"adaptive_iptw"}
-#' 
+#'
 #' @param object An object of class \code{"adaptive_iptw"}
-#' @param est A vector indicating for which estimators to return a 
-#' confidence interval. Possible estimators include the TMLE IPTW 
-#' (\code{"iptw_tmle"}, recommended), the one-step IPTW 
-#' (\code{"iptw_os"}, not recommended), the standard IPTW 
+#' @param est A vector indicating for which estimators to return a
+#' confidence interval. Possible estimators include the TMLE IPTW
+#' (\code{"iptw_tmle"}, recommended), the one-step IPTW
+#' (\code{"iptw_os"}, not recommended), the standard IPTW
 #' (\code{"iptw"}, recommended only for comparison to the other two estimators).
 #' @param level The nominal coverage probability of the desired confidence interval (should be
-#' between 0 and 1). Default computes 95\% confidence intervals. 
+#' between 0 and 1). Default computes 95\% confidence intervals.
 #' @param contrast Specifies the parameter for which to return confidence intervals.
 #' If \code{contrast=NULL}, then confidence intervals for the
 #' marginal means are computed. If instead, \code{contrast} is a numeric vector of ones, negative ones,
 #' and zeros to define linear combinations of the various means (e.g., to estimate an average
 #' treatment effect, see example). Finally, \code{contrast} can be a list with named functions
 #' \code{f}, \code{f_inv}, \code{h}, and \code{fh_grad}. The first two functions should take
-#' as input argument \code{eff}. Respectively, these specify which transformation 
+#' as input argument \code{eff}. Respectively, these specify which transformation
 #' of the effect measure to compute the confidence interval for and the inverse
 #' transformation to put the confidence interval back on the original scale. The function \code{h}
 #' defines the contrast to be estimated and should take as input \code{est}, a vector
 #' of the same length as \code{object$a_0}, and output the desired contrast. The function
-#' \code{fh_grad} is the gradient of the function \code{h}. See examples and vignette for more information. 
+#' \code{fh_grad} is the gradient of the function \code{h}. See examples and vignette for more information.
 #' @param ... Other options (not currently used).
 #' @export
 #' @method ci adaptive_iptw
 #' @return An object of class \code{"ci.adaptive_iptw"} with point estimates and
-#' confidence intervals of the specified level. 
-#' 
+#' confidence intervals of the specified level.
+#'
 #' @examples
 #' # load super learner
 #' library(SuperLearner)
@@ -191,14 +194,14 @@ ci.drtmle <- function(object, est = c("drtmle"), level = 0.95,
 #' fit1 <- adaptive_iptw(W = W, A = A, Y = Y, a_0 = c(1,0),
 #'                SL_g=c("SL.glm","SL.mean","SL.step"),
 #'                SL_Qr="SL.glm")
-#' 
+#'
 #' # get confidence intervals for each mean
 #' ci_mean <- ci(fit1)
-#' 
+#'
 #' # get confidence intervals for ATE
 #' ci_ATE <- ci(fit1, contrast = c(1,-1))
-#' 
-#' # get confidence intervals for risk ratio 
+#'
+#' # get confidence intervals for risk ratio
 #' # by inputting own contrast function
 #' # this computes CI on log scale and back transforms
 #' myContrast <- list(f = function(eff){ log(eff) },
@@ -209,82 +212,85 @@ ci.drtmle <- function(object, est = c("drtmle"), level = 0.95,
 
 
 ci.adaptive_iptw <- function(object, est = c("iptw_tmle"), level = 0.95,
-                      contrast = NULL,...){
-	if(any(est=="iptw")){
-		stop("Theory does not support inference for naive IPTW with super learner.")
-	}
-	if(class(object) != "adaptive_iptw"){
-		stop("ci only works with adaptive_iptw objects")
-	}
-	out <- vector(mode = "list", length = length(est))
-	names(out) <- est
-	# if no contrast then return an CI for each 
-	# covariate-adjusted mean
-	if(is.null(contrast)){
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = length(object$a_0), ncol = 3)
-			for(j in seq_along(object$a_0)){
-				out[[i]][j,] <-
-				  rep(object[[est[i]]]$est[j],3) + stats::qnorm(c(0.5,(1-level)/2,(1+level)/2))*
-				  	rep(sqrt(object[[est[i]]]$cov[j,j]),3)
-			}
-			row.names(out[[i]]) <- object$a_0
-			colnames(out[[i]]) <- c("est","cil","ciu")
-		}
-	}else if(is.numeric(contrast)){
-		# check that contrast came in correctly
-		if(length(contrast) != length(object$a_0)){
-			stop("length of contrast vector not equal to length of a_0")
-		}
-		if(!all(contrast %in% c(-1,1,0))){
-			stop("contrast should only be -1, 1, or 0")
-		}
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = 1, ncol = 3)
-			g <- matrix(contrast, nrow = length(contrast))
-			p <- matrix(object[[est[i]]]$est, nrow = length(contrast))
-			v <- object[[est[i]]]$cov
-			thisC <- t(g)%*%p
-			thisSe <- sqrt(t(g)%*%v%*%g)
-			out[[i]][1,] <- rep(thisC,3) + 
-					stats::qnorm(c(0.5,(1-level)/2,(1+level)/2))*rep(thisSe,3)
-			indMinus <- which(contrast == -1)
-			indPlus <- which(contrast == 1)
-			plusTerms <- minusTerms <- ""
-			if(length(indMinus) > 0){
-				minusTerms <- paste0("E[Y(",object$a_0[indMinus],")]")
-			}
-			if(length(indPlus) > 0){
-				plusTerms <- paste0("E[Y(",object$a_0[indPlus],")]")
-			}
-			thisName <- paste0(paste0(plusTerms,collapse = "+"),
-			                   ifelse(length(indMinus)>0,"-",""),
-			                   paste0(minusTerms,collapse="-"))
+                             contrast = NULL, ...) {
+  if (any(est == "iptw")) {
+    stop("Theory does not support inference for naive IPTW with super learner.")
+  }
+  if (class(object) != "adaptive_iptw") {
+    stop("ci only works with adaptive_iptw objects")
+  }
+  out <- vector(mode = "list", length = length(est))
+  names(out) <- est
+  # if no contrast then return an CI for each
+  # covariate-adjusted mean
+  if (is.null(contrast)) {
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = length(object$a_0), ncol = 3)
+      for (j in seq_along(object$a_0)) {
+        out[[i]][j, ] <-
+          rep(object[[est[i]]]$est[j], 3) + stats::qnorm(c(0.5, (1 - level) / 2, (1 + level) / 2)) *
+            rep(sqrt(object[[est[i]]]$cov[j, j]), 3)
+      }
+      row.names(out[[i]]) <- object$a_0
+      colnames(out[[i]]) <- c("est", "cil", "ciu")
+    }
+  } else if (is.numeric(contrast)) {
+    # check that contrast came in correctly
+    if (length(contrast) != length(object$a_0)) {
+      stop("length of contrast vector not equal to length of a_0")
+    }
+    if (!all(contrast %in% c(-1, 1, 0))) {
+      stop("contrast should only be -1, 1, or 0")
+    }
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = 1, ncol = 3)
+      g <- matrix(contrast, nrow = length(contrast))
+      p <- matrix(object[[est[i]]]$est, nrow = length(contrast))
+      v <- object[[est[i]]]$cov
+      thisC <- t(g) %*% p
+      thisSe <- sqrt(t(g) %*% v %*% g)
+      out[[i]][1, ] <- rep(thisC, 3) +
+        stats::qnorm(c(0.5, (1 - level) / 2, (1 + level) / 2)) * rep(thisSe, 3)
+      indMinus <- which(contrast == -1)
+      indPlus <- which(contrast == 1)
+      plusTerms <- minusTerms <- ""
+      if (length(indMinus) > 0) {
+        minusTerms <- paste0("E[Y(", object$a_0[indMinus], ")]")
+      }
+      if (length(indPlus) > 0) {
+        plusTerms <- paste0("E[Y(", object$a_0[indPlus], ")]")
+      }
+      thisName <- paste0(
+        paste0(plusTerms, collapse = "+"),
+        ifelse(length(indMinus) > 0, "-", ""),
+        paste0(minusTerms, collapse = "-")
+      )
 
-			row.names(out[[i]]) <- thisName
-			colnames(out[[i]]) <- c("est","cil","ciu")
-		}
-	}else if(is.list(contrast)){
-		if(!all(c("f","f_inv","h","fh_grad") %in% names(contrast))){
-			stop("some function missing in contrast.")
-		}
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = 1, ncol = 3)
-			thisC <- do.call(contrast$h,args=list(est = object[[est[i]]]$est))
-			f_thisC <- do.call(contrast$f,args=list(eff = thisC))
+      row.names(out[[i]]) <- thisName
+      colnames(out[[i]]) <- c("est", "cil", "ciu")
+    }
+  } else if (is.list(contrast)) {
+    if (!all(c("f", "f_inv", "h", "fh_grad") %in% names(contrast))) {
+      stop("some function missing in contrast.")
+    }
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = 1, ncol = 3)
+      thisC <- do.call(contrast$h, args = list(est = object[[est[i]]]$est))
+      f_thisC <- do.call(contrast$f, args = list(eff = thisC))
 
-			grad <- matrix(do.call(contrast$fh_grad,
-			                       args=list(est = object[[est[i]]]$est)
-			               ),nrow = length(object$a_0))
-			v <- object[[est[i]]]$cov
-			thisSe <- sqrt(t(grad)%*%v%*%grad)
-			transformCI <- rep(f_thisC,3) + stats::qnorm(c(0.5,(1-level)/2,(1+level)/2))*
-				rep(thisSe,3)
-			out[[i]][1,] <- do.call(contrast$f_inv, args = list(eff = transformCI))
-			row.names(out[[i]]) <- c("user contrast")
-			colnames(out[[i]]) <- c("est","cil","ciu")
-		}
-	}
-	class(out) <- "ci.adaptive_iptw"
-	return(out)
+      grad <- matrix(do.call(
+        contrast$fh_grad,
+        args = list(est = object[[est[i]]]$est)
+      ), nrow = length(object$a_0))
+      v <- object[[est[i]]]$cov
+      thisSe <- sqrt(t(grad) %*% v %*% grad)
+      transformCI <- rep(f_thisC, 3) + stats::qnorm(c(0.5, (1 - level) / 2, (1 + level) / 2)) *
+        rep(thisSe, 3)
+      out[[i]][1, ] <- do.call(contrast$f_inv, args = list(eff = transformCI))
+      row.names(out[[i]]) <- c("user contrast")
+      colnames(out[[i]]) <- c("est", "cil", "ciu")
+    }
+  }
+  class(out) <- "ci.adaptive_iptw"
+  return(out)
 }

--- a/R/drtmle.R
+++ b/R/drtmle.R
@@ -3,12 +3,12 @@
 #' @param W A \code{data.frame} of named covariates.
 #' @param A A \code{numeric} vector of discrete-valued treatment assignment.
 #' @param Y A \code{numeric} continuous or binary outcomes.
-#' @param DeltaY A \code{numeric} vector of missing outcome indicator (assumed to be equal to 0
-#' if missing 1 if observed).
-#' @param DeltaA A \code{numeric} vector of missing treatment indicator (assumed to be equal to
-#' 0 if missing 1 if observed).
-#' @param a_0 A \code{numeric} vector of fixed treatment values at which to return marginal
-#' mean estimates.
+#' @param DeltaY A \code{numeric} vector of missing outcome indicator (assumed
+#' to be equal to 0 if missing 1 if observed).
+#' @param DeltaA A \code{numeric} vector of missing treatment indicator (assumed
+#' to be equal to 0 if missing 1 if observed).
+#' @param a_0 A \code{numeric} vector of fixed treatment values at which to
+#' return marginal mean estimates.
 #' @param family A \code{family} object equal to either \code{binomial()} or
 #' \code{gaussian()}, to be passed to the \code{SuperLearner} or \code{glm}
 #' function.
@@ -40,22 +40,22 @@
 #' \code{SL_Qr!=NULL}. The formula should use the variable name \code{'gn'}.
 #' @param glm_gr A character describing a formula to be used in the call to
 #' \code{glm} for the reduced-dimension propensity score. Ignored if
-#' \code{SL_gr!=NULL}. The formula should use the variable name \code{'Qn'} and 
+#' \code{SL_gr!=NULL}. The formula should use the variable name \code{'Qn'} and
 #' \code{'gn'} if \code{reduction='bivariate'} and \code{'Qn'} otherwise.
-#' @param guard A character vector indicating what pattern of misspecifications 
+#' @param guard A character vector indicating what pattern of misspecifications
 #' to guard against. If \code{guard} contains \code{"Q"}, then the TMLE guards
 #' against misspecification of the outcome regression by estimating the
 #' reduced-dimension outcome regression specified by \code{glm_Qr} or
 #' \code{SL_Qr}. If \code{guard} contains \code{"g"} then the TMLE
 #' (additionally) guards against misspecification of the propensity score by
-#' estimating the reduced-dimension propensity score specified by \code{glm_gr} 
+#' estimating the reduced-dimension propensity score specified by \code{glm_gr}
 #' or \code{SL_gr}.
 #' @param reduction A character equal to \code{"univariate"} for a univariate
 #' misspecification correction (default) or \code{"bivariate"}
 #' for the bivariate version.
 #' @param returnModels A boolean indicating whether to return model fits for the
 #' outcome regression, propensity score, and reduced-dimension regressions.
-#' @param maxIter A numeric that sets the maximum number of iterations the TMLE 
+#' @param maxIter A numeric that sets the maximum number of iterations the TMLE
 #' can perform in its fluctuation step.
 #' @param tolIC A numeric that defines the stopping criteria based on the
 #' empirical mean of the influence function.
@@ -72,11 +72,11 @@
 #' vector of fold assignments for observations, in which case its length should
 #' be the same length as \code{Y}.
 #' @param parallel A boolean indicating whether to use parallelization based on
-#' \code{future} when estimating nuisance parameters. 
-#' Only useful if \code{cvFolds > 1}. By default, a \code{multiprocess} evaluation 
-#' scheme is invoked, using forked R processes
-#' (if supported on the OS) and background R sessions otherwise. Users may also
-#' register their own backends using the \code{future.batchtools} package.
+#' \code{future} when estimating nuisance parameters.
+#' Only useful if \code{cvFolds > 1}. By default, a \code{multiprocess}
+#' evaluation scheme is invoked, using forked R processes (if supported on the
+#' OS) and background R sessions otherwise. Users may also register their own
+#' backends using the \code{future.batchtools} package.
 #' @param future_hpc A character string identifying a high-performance computing
 #' backend to be used with parallelization. This should match exactly one of the
 #' options available from the \code{future.batchtools} package.
@@ -103,17 +103,17 @@
 #'        a doubly-robust covariance matrix}
 #'  \item{\code{nuisance_drtmle}}{A \code{list} of the final TMLE estimates of
 #'        the outcome regression (\code{$QnStar}), propensity score
-#'        (\code{$gnStar}), and reduced-dimension regressions (\code{$QrnStar}, 
+#'        (\code{$gnStar}), and reduced-dimension regressions (\code{$QrnStar},
 #'        \code{$grnStar}) evaluated at the observed data values.}
 #'  \item{\code{ic_drtmle}}{A \code{list} of the empirical mean of the efficient
 #'        influence function (\code{$eif}) and the extra pieces of the influence
 #'        function resulting from misspecification. All should be smaller than
 #'        \code{tolIC} (unless \code{maxIter} was reached first). Also includes
-#'        a matrix of the influence function at the estimated nuisance parameters
-#'        evaluated at the observed data.}
+#'        a matrix of the influence function values at the estimated nuisance
+#'        parameters evaluated at the observed data.}
 #'  \item{\code{aiptw_c}}{A \code{list} of doubly-robust point estimates and
 #'        a non-doubly-robust covariance matrix. Theory does not guarantee
-#'        performance of inference for these estimators, but simulation studies 
+#'        performance of inference for these estimators, but simulation studies
 #'        showed they often perform adequately.}
 #'  \item{\code{nuisance_aiptw}}{A \code{list} of the initial estimates of the
 #'        outcome regression, propensity score, and reduced-dimension
@@ -130,11 +130,11 @@
 #'        \code{NULL} if \code{returnModels = FALSE}.}
 #'  \item{\code{gnMod}}{The fitted object for the propensity score. Returns
 #'        \code{NULL} if \code{returnModels = FALSE}.}
-#'  \item{\code{QrnMod}}{The fitted object for the reduced-dimension regression 
+#'  \item{\code{QrnMod}}{The fitted object for the reduced-dimension regression
 #'        that guards against misspecification of the outcome regression.
 #'        Returns \code{NULL} if \code{returnModels = FALSE}.}
-#'  \item{\code{grnMod}}{The fitted object for the reduced-dimension regression 
-#'        that guards against misspecification of the propensity score. Returns 
+#'  \item{\code{grnMod}}{The fitted object for the reduced-dimension regression
+#'        that guards against misspecification of the propensity score. Returns
 #'        \code{NULL} if \code{returnModels = FALSE}.}
 #'  \item{\code{a_0}}{The treatment levels that were requested for computation
 #'        of covariate-adjusted means.}
@@ -162,7 +162,7 @@
 #' # A quick example of drtmle:
 #' # We note that more flexible super learner libraries
 #' # are available, and that we recommend the user use more flexible
-#' # libraries for SL_Qr and SL_gr for general use. 
+#' # libraries for SL_Qr and SL_gr for general use.
 #' fit1 <- drtmle(W = W, A = A, Y = Y, a_0 = c(1,0),
 #'                family=binomial(),
 #'                stratify=FALSE,
@@ -175,9 +175,11 @@ drtmle <- function(Y, A, W,
                    DeltaA = as.numeric(!is.na(A)),
                    DeltaY = as.numeric(!is.na(Y)),
                    a_0 = unique(A[!is.na(A)]),
-                   family = if(all(Y %in% c(0, 1))) {
-                    stats::binomial()
-                   } else { stats::gaussian() },
+                   family = if (all(Y %in% c(0, 1))) {
+                     stats::binomial()
+                   } else {
+                     stats::gaussian()
+                   },
                    stratify = TRUE,
                    SL_Q = NULL, SL_g = NULL,
                    SL_Qr = NULL, SL_gr = NULL,
@@ -205,7 +207,7 @@ drtmle <- function(Y, A, W,
     # comes in as vector of fold assignments
     # split up into a list of id's
     validRows <- sapply(sort(unique(cvFolds)), function(f) {
-      which (cvFolds == f)
+      which(cvFolds == f)
     })
   } else if (cvFolds != 1) {
     # split data up
@@ -216,52 +218,66 @@ drtmle <- function(Y, A, W,
   }
   # use futures with foreach if parallel mode
   if (!parallel) {
-    future::plan(future::sequential)
+    future::plan(future::transparent)
   } else {
     doFuture::registerDoFuture()
     if (all(c("sequential", "uniprocess") %in% class(future::plan())) &
-        is.null(future_hpc)) {
+      is.null(future_hpc)) {
       future::plan(future::multiprocess)
     } else if (!is.null(future_hpc)) {
-      set_future_hpc <- parse(text = paste0("future.batchtools", "::",
-                                            future_hpc))
-      future::plan(eval(set_future_hpc))
+      if (future_hpc == "batchtools_torque") {
+        future::plan(future.batchtools::batchtools_torque)
+      } else if (future_hpc == "batchtools_slurm") {
+        future::plan(future.batchtools::batchtools_slurm)
+      } else if (future_hpc == "batchtools_sge") {
+        future::plan(future.batchtools::batchtools_sge)
+      } else if (future_hpc == "batchtools_lsf") {
+        future::plan(future.batchtools::batchtools_lsf)
+      } else if (future_hpc == "batchtools_openlava") {
+        future::plan(future.batchtools::batchtools_openlava)
+      } else {
+        stop("The currently specified HPC backend is not (yet) available.")
+      }
     }
   }
-  #-------------------------------
+  # -------------------------------
   # estimate propensity score
-  #-------------------------------
+  # -------------------------------
   if (is.null(gn)) {
-    gnOut <- future::future_lapply(x = validRows, FUN = estimateG, A = A,
-                                   W = W, DeltaA = DeltaA, DeltaY = DeltaY,
-                                   tolg = tolg, verbose = verbose,
-                                   stratify = stratify,
-                                   returnModels = returnModels, SL_g = SL_g,
-                                   glm_g = glm_g, a_0 = a_0)
+    gnOut <- future::future_lapply(
+      x = validRows, FUN = estimateG, A = A,
+      W = W, DeltaA = DeltaA, DeltaY = DeltaY,
+      tolg = tolg, verbose = verbose,
+      stratify = stratify,
+      returnModels = returnModels, SL_g = SL_g,
+      glm_g = glm_g, a_0 = a_0
+    )
     # # re-order predictions
     gnValid <- unlist(gnOut, recursive = FALSE, use.names = FALSE)
     gnUnOrd <- do.call(Map, c(c, gnValid[seq(1, length(gnValid), 2)]))
     gn <- vector(mode = "list", length = length(a_0))
-    for(i in seq_along(a_0)){
+    for (i in seq_along(a_0)) {
       gn[[i]] <- rep(NA, n)
       gn[[i]][unlist(validRows)] <- gnUnOrd[[i]]
     }
     # obtain list of propensity score fits
     gnMod <- gnValid[seq(2, length(gnValid), 2)]
   }
-  #-------------------------------
+  # -------------------------------
   # estimate outcome regression
-  #-------------------------------
+  # -------------------------------
   if (is.null(Qn)) {
-    QnOut <- future::future_lapply(x = validRows, FUN = estimateQ,
-                                   Y = Y, A = A, W = W,
-                                   DeltaA = DeltaA, DeltaY = DeltaY,
-                                   verbose = verbose,
-                                   returnModels = returnModels,
-                                   SL_Q = SL_Q, a_0 = a_0,
-                                   stratify = stratify,
-                                   glm_Q = glm_Q,
-                                   family = family)
+    QnOut <- future::future_lapply(
+      x = validRows, FUN = estimateQ,
+      Y = Y, A = A, W = W,
+      DeltaA = DeltaA, DeltaY = DeltaY,
+      verbose = verbose,
+      returnModels = returnModels,
+      SL_Q = SL_Q, a_0 = a_0,
+      stratify = stratify,
+      glm_Q = glm_Q,
+      family = family
+    )
     # re-order predictions
     QnValid <- unlist(QnOut, recursive = FALSE, use.names = FALSE)
     QnUnOrd <- do.call(Map, c(c, QnValid[seq(1, length(QnValid), 2)]))
@@ -277,8 +293,10 @@ drtmle <- function(Y, A, W,
   psi_n <- lapply(Qn, mean)
 
   # estimate influence function
-  Dno <- eval_Dstar(A = A, Y = Y, DeltaY = DeltaY, DeltaA = DeltaA,
-                    Qn = Qn, gn = gn, psi_n = psi_n, a_0 = a_0)
+  Dno <- eval_Dstar(
+    A = A, Y = Y, DeltaY = DeltaY, DeltaA = DeltaA,
+    Qn = Qn, gn = gn, psi_n = psi_n, a_0 = a_0
+  )
 
   # estimate bias correction
   PnDn <- lapply(Dno, mean)
@@ -289,12 +307,14 @@ drtmle <- function(Y, A, W,
   PnDQn <- PnDgn <- 0
 
   if ("Q" %in% guard) {
-    QrnOut <- future::future_lapply(x = validRows, FUN = estimateQrn,
-                                    Y = Y, A = A, W = W,
-                                    DeltaA = DeltaA, DeltaY = DeltaY,
-                                    Qn = Qn, gn = gn, glm_Qr = glm_Qr,
-                                    family = stats::gaussian(), SL_Qr = SL_Qr,
-                                    a_0 = a_0, returnModels = returnModels)
+    QrnOut <- future::future_lapply(
+      x = validRows, FUN = estimateQrn,
+      Y = Y, A = A, W = W,
+      DeltaA = DeltaA, DeltaY = DeltaY,
+      Qn = Qn, gn = gn, glm_Qr = glm_Qr,
+      family = stats::gaussian(), SL_Qr = SL_Qr,
+      a_0 = a_0, returnModels = returnModels
+    )
     # re-order predictions
     QrnValid <- unlist(QrnOut, recursive = FALSE, use.names = FALSE)
     QrnUnOrd <- do.call(Map, c(c, QrnValid[seq(1, length(QrnValid), 2)]))
@@ -306,18 +326,22 @@ drtmle <- function(Y, A, W,
     # obtain list of reduced dimension regression fits
     QrnMod <- QrnValid[seq(2, length(QrnValid), 2)]
 
-    Dngo <- eval_Dstar_g(A = A, DeltaY = DeltaY, DeltaA = DeltaA, Qrn = Qrn,
-                         gn = gn, a_0 = a_0)
+    Dngo <- eval_Dstar_g(
+      A = A, DeltaY = DeltaY, DeltaA = DeltaA, Qrn = Qrn,
+      gn = gn, a_0 = a_0
+    )
     PnDgn <- lapply(Dngo, mean)
   }
   if ("g" %in% guard) {
-    grnOut <- future::future_lapply(x = validRows, FUN = estimategrn,
-                                    Y = Y, A = A, W = W,
-                                    DeltaA = DeltaA, DeltaY = DeltaY,
-                                    tolg = tolg, Qn = Qn, gn = gn,
-                                    glm_gr = glm_gr, SL_gr = SL_gr, a_0 = a_0,
-                                    reduction = reduction,
-                                    returnModels = returnModels)
+    grnOut <- future::future_lapply(
+      x = validRows, FUN = estimategrn,
+      Y = Y, A = A, W = W,
+      DeltaA = DeltaA, DeltaY = DeltaY,
+      tolg = tolg, Qn = Qn, gn = gn,
+      glm_gr = glm_gr, SL_gr = SL_gr, a_0 = a_0,
+      reduction = reduction,
+      returnModels = returnModels
+    )
     # re-order predictions
     grnValid <- unlist(grnOut, recursive = FALSE, use.names = FALSE)
     grnUnOrd <- do.call(Map, c(rbind, grnValid[seq(1, length(grnValid), 2)]))
@@ -330,22 +354,34 @@ drtmle <- function(Y, A, W,
     grnMod <- grnValid[seq(2, length(grnValid), 2)]
 
     # evaluate extra piece of influence function
-    DnQo <- eval_Dstar_Q(A = A, Y = Y, DeltaY = DeltaY, DeltaA = DeltaA,
-                         Qn = Qn, grn = grn, gn = gn, a_0 = a_0,
-                         reduction = reduction)
+    DnQo <- eval_Dstar_Q(
+      A = A, Y = Y, DeltaY = DeltaY, DeltaA = DeltaA,
+      Qn = Qn, grn = grn, gn = gn, a_0 = a_0,
+      reduction = reduction
+    )
     PnDQn <- lapply(DnQo, mean)
   }
 
   # one step estimates
-  psi_o1 <- mapply(a = psi_n, b = PnDn, SIMPLIFY = FALSE,
-                   FUN = function(a, b){ a + b })
-  psi_o <- mapply(a = psi_n, b = PnDn, c = PnDQn, d = PnDgn, SIMPLIFY = FALSE,
-                  FUN = function(a, b, c, d){ a + b - c - d })
+  psi_o1 <- mapply(
+    a = psi_n, b = PnDn, SIMPLIFY = FALSE,
+    FUN = function(a, b) {
+      a + b
+    }
+  )
+  psi_o <- mapply(
+    a = psi_n, b = PnDn, c = PnDQn, d = PnDgn, SIMPLIFY = FALSE,
+    FUN = function(a, b, c, d) {
+      a + b - c - d
+    }
+  )
 
   # covariance for one step
   Dno1Mat <- matrix(unlist(Dno), nrow = n, ncol = length(a_0))
-  DnoMat <- matrix(unlist(Dno) - unlist(DnQo) - unlist(Dngo),
-                   nrow = n, ncol = length(a_0))
+  DnoMat <- matrix(
+    unlist(Dno) - unlist(DnQo) - unlist(Dngo),
+    nrow = n, ncol = length(a_0)
+  )
 
   cov_o1 <- stats::cov(Dno1Mat) / n
   cov_o <- stats::cov(DnoMat) / n
@@ -354,43 +390,51 @@ drtmle <- function(Y, A, W,
   QnStar <- Qn
   if ("g" %in% guard) grnStar <- grn
   if ("Q" %in% guard) QrnStar <- Qrn
-  gnStar <- gn;
+  gnStar <- gn
   PnDQnStar <- PnDgnStar <- PnDnoStar <- Inf
   eps <- list(Inf)
   ct <- 0
 
   # fluctuate
-  while(max(abs(c(unlist(PnDQnStar), unlist(PnDgnStar), unlist(PnDnoStar)))) > 
-        tolIC & ct < maxIter){
+  while (max(abs(c(unlist(PnDQnStar), unlist(PnDgnStar), unlist(PnDnoStar)))) >
+    tolIC & ct < maxIter) {
     ct <- ct + 1
 
     # re-estimate Qrn
     if ("Q" %in% guard) {
       # fluctuate gnStar
-      gnStarOut <- fluctuateG(Y = Y, A = A, W = W, DeltaA = DeltaA,
-                              DeltaY = DeltaY, a_0 = a_0, tolg = tolg,
-                              gn = gnStar, Qrn = QrnStar)
-      gnStar <- plyr::llply(gnStarOut, function(x){ unlist(x$est) })
-      epsg <- plyr::laply(gnStarOut, function(x){ x$eps })
+      gnStarOut <- fluctuateG(
+        Y = Y, A = A, W = W, DeltaA = DeltaA,
+        DeltaY = DeltaY, a_0 = a_0, tolg = tolg,
+        gn = gnStar, Qrn = QrnStar
+      )
+      gnStar <- plyr::llply(gnStarOut, function(x) {
+        unlist(x$est)
+      })
+      epsg <- plyr::laply(gnStarOut, function(x) {
+        x$eps
+      })
     } else {
       epsg <- NA
     }
 
     # fluctuate QnStar
     if ("g" %in% guard) {
-      grnStarOut <- future::future_lapply(x = validRows, FUN = estimategrn,
-                                          Y = Y, A = A, W = W,
-                                          DeltaA = DeltaA, DeltaY = DeltaY,
-                                          tolg = tolg, Qn = QnStar,
-                                          gn = gnStar, glm_gr = glm_gr,
-                                          SL_gr = SL_gr, a_0 = a_0,
-                                          reduction = reduction,
-                                          returnModels = returnModels)
+      grnStarOut <- future::future_lapply(
+        x = validRows, FUN = estimategrn,
+        Y = Y, A = A, W = W,
+        DeltaA = DeltaA, DeltaY = DeltaY,
+        tolg = tolg, Qn = QnStar,
+        gn = gnStar, glm_gr = glm_gr,
+        SL_gr = SL_gr, a_0 = a_0,
+        reduction = reduction,
+        returnModels = returnModels
+      )
       # re-order predictions
       grnValid <- unlist(grnStarOut, recursive = FALSE, use.names = FALSE)
-      grnUnOrd <- do.call(Map, c(rbind, grnValid[seq(1,length(grnValid),2)]))
+      grnUnOrd <- do.call(Map, c(rbind, grnValid[seq(1, length(grnValid), 2)]))
       grnStar <- vector(mode = "list", length = length(a_0))
-      for(i in 1:length(a_0)){
+      for (i in 1:length(a_0)) {
         grnStar[[i]] <- data.frame(grn1 = rep(NA, n), grn2 = rep(NA, n))
         grnStar[[i]][unlist(validRows), ] <- cbind(grnUnOrd[[i]])
       }
@@ -398,48 +442,70 @@ drtmle <- function(Y, A, W,
       grnMod <- grnValid[seq(2, length(grnValid), 2)]
 
       if (Qsteps == 1) {
-        QnStarOut <- fluctuateQ(Y = Y, A = A, W = W, DeltaA = DeltaA,
-                                DeltaY = DeltaY, a_0 = a_0, Qn = QnStar,
-                                gn = gnStar, grn = grnStar,
-                                reduction = reduction)
-        QnStar <- plyr::llply(QnStarOut, function(x){ unlist(x$est) })
-        epsQ <- plyr::laply(QnStarOut, function(x){ x$eps })
+        QnStarOut <- fluctuateQ(
+          Y = Y, A = A, W = W, DeltaA = DeltaA,
+          DeltaY = DeltaY, a_0 = a_0, Qn = QnStar,
+          gn = gnStar, grn = grnStar,
+          reduction = reduction
+        )
+        QnStar <- plyr::llply(QnStarOut, function(x) {
+          unlist(x$est)
+        })
+        epsQ <- plyr::laply(QnStarOut, function(x) {
+          x$eps
+        })
       } else if (Qsteps == 2) {
         # do the extra targeting
-        QnStarOut2 <- fluctuateQ2(Y = Y, A = A, W = W, DeltaA = DeltaA,
-                                  DeltaY = DeltaY, a_0 = a_0, Qn = QnStar,
-                                  gn = gnStar, grn = grnStar,
-                                  reduction = reduction)
-        QnStar <- plyr::llply(QnStarOut2, function(x){ unlist(x[[1]]) })
+        QnStarOut2 <- fluctuateQ2(
+          Y = Y, A = A, W = W, DeltaA = DeltaA,
+          DeltaY = DeltaY, a_0 = a_0, Qn = QnStar,
+          gn = gnStar, grn = grnStar,
+          reduction = reduction
+        )
+        QnStar <- plyr::llply(QnStarOut2, function(x) {
+          unlist(x[[1]])
+        })
 
         # do the usual targeting
-        QnStarOut1 <- fluctuateQ1(Y = Y, A = A, W = W, DeltaA = DeltaA,
-                                  DeltaY = DeltaY, a_0 = a_0, Qn = QnStar,
-                                  gn = gnStar)
-        QnStar <- plyr::llply(QnStarOut1, function(x){ unlist(x[[1]]) })
+        QnStarOut1 <- fluctuateQ1(
+          Y = Y, A = A, W = W, DeltaA = DeltaA,
+          DeltaY = DeltaY, a_0 = a_0, Qn = QnStar,
+          gn = gnStar
+        )
+        QnStar <- plyr::llply(QnStarOut1, function(x) {
+          unlist(x[[1]])
+        })
 
         # for later retrieval of fluct coefficients
         epsQ <- mapply(q1 = QnStarOut1, q2 = QnStarOut2, function(q1, q2) {
-          c(q1$eps,q2$eps)
+          c(q1$eps, q2$eps)
         })
       }
     } else {
-      QnStarOut <- fluctuateQ1(Y = Y, A = A, W = W, DeltaA = DeltaA,
-                               DeltaY = DeltaY, a_0 = a_0, Qn = QnStar,
-                               gn = gnStar)
-      QnStar <- plyr::llply(QnStarOut, function(x){ unlist(x[[1]]) })
-      epsQ <- plyr::laply(QnStarOut, function(x){ x$eps })
+      QnStarOut <- fluctuateQ1(
+        Y = Y, A = A, W = W, DeltaA = DeltaA,
+        DeltaY = DeltaY, a_0 = a_0, Qn = QnStar,
+        gn = gnStar
+      )
+      QnStar <- plyr::llply(QnStarOut, function(x) {
+        unlist(x[[1]])
+      })
+      epsQ <- plyr::laply(QnStarOut, function(x) {
+        x$eps
+      })
     }
 
     if ("Q" %in% guard) {
-      QrnStarOut <- future::future_lapply(x = validRows, FUN = estimateQrn,
-                                          Y = Y, A = A, W = W,
-                                          DeltaA = DeltaA, DeltaY = DeltaY,
-                                          Qn = QnStar, gn = gnStar,
-                                          glm_Qr = glm_Qr,
-                                          family = stats::gaussian(),
-                                          SL_Qr = SL_Qr, a_0 = a_0,
-                                          returnModels = returnModels)
+      QrnStarOut <- future::future_lapply(
+        x = validRows, FUN = estimateQrn,
+        Y = Y, A = A, W = W,
+        DeltaA = DeltaA, DeltaY = DeltaY,
+        Qn = QnStar, gn = gnStar,
+        glm_Qr = glm_Qr,
+        family = stats::gaussian(),
+        SL_Qr = SL_Qr, a_0 = a_0,
+        returnModels = returnModels
+      )
       # re-order predictions
       QrnValid <- unlist(QrnStarOut, recursive = FALSE, use.names = FALSE)
       QrnUnOrd <- do.call(Map, c(c, QrnValid[seq(1, length(QrnValid), 2)]))
@@ -459,83 +525,113 @@ drtmle <- function(Y, A, W,
     psi_t <- lapply(QnStar, mean)
 
     # calculate influence functions
-    DnoStar <- eval_Dstar(A = A, Y = Y, DeltaY = DeltaY, DeltaA = DeltaA,
-                    Qn = QnStar, gn = gnStar, psi_n = psi_t, a_0 = a_0)
+    DnoStar <- eval_Dstar(
+      A = A, Y = Y, DeltaY = DeltaY, DeltaA = DeltaA,
+      Qn = QnStar, gn = gnStar, psi_n = psi_t, a_0 = a_0
+    )
     PnDnoStar <- lapply(DnoStar, mean)
 
     if ("g" %in% guard) {
-      DnQoStar <- eval_Dstar_Q(A = A, Y = Y, DeltaY = DeltaY,
-                         DeltaA = DeltaA, Qn = QnStar, grn = grnStar, gn = gn,
-                         a_0 = a_0, reduction = reduction)
+      DnQoStar <- eval_Dstar_Q(
+        A = A, Y = Y, DeltaY = DeltaY,
+        DeltaA = DeltaA, Qn = QnStar, grn = grnStar, gn = gn,
+        a_0 = a_0, reduction = reduction
+      )
       PnDQnStar <- lapply(DnQoStar, mean)
     }
     if ("Q" %in% guard) {
-      DngoStar <- eval_Dstar_g(A = A, DeltaY = DeltaY, DeltaA = DeltaA,
-                               Qrn = QrnStar, gn = gnStar, a_0 = a_0)
+      DngoStar <- eval_Dstar_g(
+        A = A, DeltaY = DeltaY, DeltaA = DeltaA,
+        Qrn = QrnStar, gn = gnStar, a_0 = a_0
+      )
       PnDgnStar <- lapply(DngoStar, mean)
     }
     if (verbose) {
       cat("TMLE Iteration", ct, "=", round(unlist(eps), 5), "\n")
-      cat("Mean of IC       =", round(c(unlist(PnDnoStar),
-                                        unlist(PnDQnStar),
-                                        unlist(PnDgnStar)), 10),"\n")
+      cat("Mean of IC       =", round(c(
+        unlist(PnDnoStar),
+        unlist(PnDQnStar),
+        unlist(PnDgnStar)
+      ), 10), "\n")
     }
   }
 
   # standard tmle fluctuations
-  QnStar1Out <- fluctuateQ1(Y = Y, A = A, W = W, DeltaA = DeltaA,
-                            DeltaY = DeltaY, Qn = Qn, gn = gn, a_0 = a_0)
+  QnStar1Out <- fluctuateQ1(
+    Y = Y, A = A, W = W, DeltaA = DeltaA,
+    DeltaY = DeltaY, Qn = Qn, gn = gn, a_0 = a_0
+  )
   # could potentially parallelize with future since plyr uses foreach internally
-  QnStar1 <- plyr::llply(QnStar1Out, function(x){ unlist(x[[1]]) })
+  QnStar1 <- plyr::llply(QnStar1Out, function(x) {
+    unlist(x[[1]])
+  })
 
   # tmle estimates
   psi_t <- lapply(QnStar, mean)
   psi_t1 <- lapply(QnStar1, mean)
 
   # covariance for tmle
-  Dno1Star <- eval_Dstar(A = A, Y = Y, DeltaA = DeltaA, DeltaY = DeltaY,
-                         Qn = QnStar1, gn = gn, psi_n = psi_t1, a_0 = a_0)
+  Dno1Star <- eval_Dstar(
+    A = A, Y = Y, DeltaA = DeltaA, DeltaY = DeltaY,
+    Qn = QnStar1, gn = gn, psi_n = psi_t1, a_0 = a_0
+  )
   Dno1StarMat <- matrix(unlist(Dno1Star), nrow = n, ncol = length(a_0))
   cov_t1 <- stats::cov(Dno1StarMat)
 
   # covariance for drtmle
-  DnoStar <- eval_Dstar(A = A, Y = Y, DeltaA = DeltaA, DeltaY = DeltaY,
-                        Qn = QnStar, gn = gnStar, psi_n = psi_t, a_0 = a_0)
+  DnoStar <- eval_Dstar(
+    A = A, Y = Y, DeltaA = DeltaA, DeltaY = DeltaY,
+    Qn = QnStar, gn = gnStar, psi_n = psi_t, a_0 = a_0
+  )
   PnDnoStar <- lapply(DnoStar, mean)
 
   DnQoStar <- rep(list(rep(0, n)), length(a_0))
   DngoStar <- rep(list(rep(0, n)), length(a_0))
 
   if ("g" %in% guard) {
-    DnQoStar <- eval_Dstar_Q(A = A, Y = Y, DeltaY = DeltaY,
-                       DeltaA = DeltaA, Qn = QnStar, grn = grnStar, gn = gn,
-                       a_0 = a_0, reduction = reduction)
+    DnQoStar <- eval_Dstar_Q(
+      A = A, Y = Y, DeltaY = DeltaY,
+      DeltaA = DeltaA, Qn = QnStar, grn = grnStar, gn = gn,
+      a_0 = a_0, reduction = reduction
+    )
     PnDQnStar <- lapply(DnQoStar, mean)
   }
   if ("Q" %in% guard) {
-    DngoStar <- eval_Dstar_g(A = A, DeltaY = DeltaY, DeltaA = DeltaA,
-                             Qrn = QrnStar, gn = gnStar, a_0 = a_0)
+    DngoStar <- eval_Dstar_g(
+      A = A, DeltaY = DeltaY, DeltaA = DeltaA,
+      Qrn = QrnStar, gn = gnStar, a_0 = a_0
+    )
     PnDgnStar <- lapply(DngoStar, mean)
   }
 
-  DnoStarMat <- matrix(unlist(DnoStar) - unlist(DnQoStar) - unlist(DngoStar),
-                       nrow = n, ncol = length(a_0))
+  DnoStarMat <- matrix(
+    unlist(DnoStar) - unlist(DnQoStar) - unlist(DngoStar),
+    nrow = n, ncol = length(a_0)
+  )
   cov_t <- stats::cov(DnoStarMat) / n
 
-  out <- list(drtmle = list(est = unlist(psi_t), cov = cov_t),
-              nuisance_drtmle = list(QnStar = QnStar, gnStar = gnStar,
-                                     QrnStar = QrnStar, grnStar = grn,
-                                     meanIC = unlist(c(PnDnoStar, PnDQnStar,
-                                                       PnDgnStar))),
-              ic_drtmle = list(mean_eif = PnDnoStar, mean_missQ = PnDgnStar,
-                               mean_missg = PnDQnStar, ic = DnoStarMat),
-              aiptw_c = list(est = unlist(psi_o),cov=cov_o),
-              nuisance_aiptw_c = list(Qn = Qn, gn = gn, Qrn = Qrn, grn = grn),
-              tmle = list(est = unlist(psi_t1),cov = cov_t1),
-              aiptw = list(est = unlist(psi_o1), cov = cov_o1),
-              gcomp=list(est = unlist(psi_n), cov = cov_o1),
-              QnMod = NULL, gnMod = NULL, QrnMod = NULL, grnMod = NULL,
-              a_0 = a_0, call = call)
+  out <- list(
+    drtmle = list(est = unlist(psi_t), cov = cov_t),
+    nuisance_drtmle = list(
+      QnStar = QnStar, gnStar = gnStar,
+      QrnStar = QrnStar, grnStar = grn,
+      meanIC = unlist(c(
+        PnDnoStar, PnDQnStar,
+        PnDgnStar
+      ))
+    ),
+    ic_drtmle = list(
+      mean_eif = PnDnoStar, mean_missQ = PnDgnStar,
+      mean_missg = PnDQnStar, ic = DnoStarMat
+    ),
+    aiptw_c = list(est = unlist(psi_o), cov = cov_o),
+    nuisance_aiptw_c = list(Qn = Qn, gn = gn, Qrn = Qrn, grn = grn),
+    tmle = list(est = unlist(psi_t1), cov = cov_t1),
+    aiptw = list(est = unlist(psi_o1), cov = cov_o1),
+    gcomp = list(est = unlist(psi_n), cov = cov_o1),
+    QnMod = NULL, gnMod = NULL, QrnMod = NULL, grnMod = NULL,
+    a_0 = a_0, call = call
+  )
 
   # tack on models if requested
   if (returnModels) {
@@ -547,4 +643,3 @@ drtmle <- function(Y, A, W,
   class(out) <- "drtmle"
   return(out)
 }
-

--- a/R/estimate.R
+++ b/R/estimate.R
@@ -1,1016 +1,1174 @@
 #' estimateG
-#' 
+#'
 #' Function to estimate propensity score
-#' 
+#'
 #' @importFrom plyr alply
 #' @param A A vector of binary treatment assignment (assumed to be equal to 0 or
 #' 1)
-#' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if 
+#' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if
 #' missing 1 if observed)
-#' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if 
+#' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if
 #' missing 1 if observed)
 #' @param W A \code{data.frame} of named covariates
-#' @param stratify A \code{boolean} indicating whether to estimate the missing 
+#' @param stratify A \code{boolean} indicating whether to estimate the missing
 #' outcome regression separately
-#' for observations with \code{A} equal to 0/1 (if \code{TRUE}) or to pool 
+#' for observations with \code{A} equal to 0/1 (if \code{TRUE}) or to pool
 #' across \code{A} (if \code{FALSE}).
-#' @param SL_g A vector of characters describing the super learner library to be 
-#' used for each of the regression (\code{DeltaA}, \code{A}, and \code{DeltaY}). 
-#' To use the same regression for each of the regressions (or if there is no 
-#' missing data in \code{A} nor \code{Y}), a single library may be input. 
-#' @param tolg A numeric indicating the minimum value for estimates of the 
+#' @param SL_g A vector of characters describing the super learner library to be
+#' used for each of the regression (\code{DeltaA}, \code{A}, and \code{DeltaY}).
+#' To use the same regression for each of the regressions (or if there is no
+#' missing data in \code{A} nor \code{Y}), a single library may be input.
+#' @param tolg A numeric indicating the minimum value for estimates of the
 #' propensity score.
 #' @param verbose A boolean indicating whether to print status updates.
-#' @param returnModels A boolean indicating whether to return model fits for the 
+#' @param returnModels A boolean indicating whether to return model fits for the
 #' outcome regression, propensity score, and reduced-dimension regressions.
-#' @param glm_g A character describing a formula to be used in the call to 
+#' @param glm_g A character describing a formula to be used in the call to
 #' \code{glm} for the propensity score.
-#' @param a_0 A vector of fixed treatment values at which to return marginal 
+#' @param a_0 A vector of fixed treatment values at which to return marginal
 #' mean estimates.
-#' @param validRows A \code{list} of length \code{cvFolds} containing the row 
-#' indexes of observations to include in validation fold. 
+#' @param validRows A \code{list} of length \code{cvFolds} containing the row
+#' indexes of observations to include in validation fold.
 #' @importFrom SuperLearner SuperLearner trimLogit
 #' @importFrom stats predict glm as.formula
-#' 
+#'
 
-estimateG <- function(A, W, DeltaY, DeltaA, SL_g, glm_g, a_0, tolg, 
-    stratify = FALSE, validRows = NULL, verbose = FALSE, returnModels = FALSE) {
-    if (is.null(SL_g) & is.null(glm_g)) 
-        stop("Specify Super Learner library or GLM formula for g")
-    if (!is.null(SL_g) & !is.null(glm_g)) {
-        warning(paste0("Super Learner library and GLM formula specified.", 
-          "Proceeding with Super Learner only."))
-        glm_g <- NULL
+estimateG <- function(A, W, DeltaY, DeltaA, SL_g, glm_g, a_0, tolg,
+                      stratify = FALSE, validRows = NULL, verbose = FALSE, returnModels = FALSE) {
+  if (is.null(SL_g) & is.null(glm_g)) {
+    stop("Specify Super Learner library or GLM formula for g")
+  }
+  if (!is.null(SL_g) & !is.null(glm_g)) {
+    warning(paste0(
+      "Super Learner library and GLM formula specified.",
+      "Proceeding with Super Learner only."
+    ))
+    glm_g <- NULL
+  }
+
+  # subset data into training and validation sets
+  if (length(validRows) != length(A)) {
+    trainDeltaA <- DeltaA[-validRows]
+    trainDeltaY <- DeltaY[-validRows]
+    trainA <- A[-validRows]
+    trainW <- W[-validRows, , drop = FALSE]
+    validW <- W[validRows, , drop = FALSE]
+    validA <- A[validRows]
+    validDeltaA <- DeltaA[validRows]
+    validDeltaY <- DeltaY[validRows]
+  } else {
+    trainA <- validA <- A
+    trainW <- validW <- W
+    trainDeltaA <- validDeltaA <- DeltaA
+    trainDeltaY <- validDeltaY <- DeltaY
+  }
+
+  if (!is.null(SL_g)) {
+    # check for names in SL_g
+    namedSL_g <- c("DeltaA", "A", "DeltaY") %in% names(SL_g)
+    # if none of the above names appear, then it is assumed that you want
+    # to use SL_g for each of DeltaA, A, and Y
+    if (!any(namedSL_g)) {
+      SL_g <- list(DeltaA = SL_g, A = SL_g, DeltaY = SL_g)
     }
-    
-    # subset data into training and validation sets
-    if (length(validRows) != length(A)) {
-        trainDeltaA <- DeltaA[-validRows]
-        trainDeltaY <- DeltaY[-validRows]
-        trainA <- A[-validRows]
-        trainW <- W[-validRows, , drop = FALSE]
-        validW <- W[validRows, , drop = FALSE]
-        validA <- A[validRows]
-        validDeltaA <- DeltaA[validRows]
-        validDeltaY <- DeltaY[validRows]
-    } else {
-        trainA <- validA <- A
-        trainW <- validW <- W
-        trainDeltaA <- validDeltaA <- DeltaA
-        trainDeltaY <- validDeltaY <- DeltaY
+  } else if (!is.null(glm_g)) {
+    namedglm_g <- c("DeltaA", "A", "DeltaY") %in% names(glm_g)
+    # if none of the above names appear, then it is assumed that you want
+    # to use glm_g for each of DeltaA, A, and Y
+    if (!any(namedglm_g)) {
+      glm_g <- list(DeltaA = glm_g, A = glm_g, DeltaY = glm_g)
     }
-    
+  }
+
+  # -------------------------------
+  # regression of DeltaA ~ W
+  # -------------------------------
+  # only fit this regression if there are some missing treatment assignments
+  if (!all(DeltaA == 1)) {
+    # if super learner library is specified, fit a super learner
     if (!is.null(SL_g)) {
-        # check for names in SL_g
-        namedSL_g <- c("DeltaA", "A", "DeltaY") %in% names(SL_g)
-        # if none of the above names appear, then it is assumed that you want 
-        # to use SL_g for each of DeltaA, A, and Y
-        if (!any(namedSL_g)) {
-            SL_g <- list(DeltaA = SL_g, A = SL_g, DeltaY = SL_g)
-        }
-    } else if (!is.null(glm_g)) {
-        namedglm_g <- c("DeltaA", "A", "DeltaY") %in% names(glm_g)
-        # if none of the above names appear, then it is assumed that you want 
-        # to use glm_g for each of DeltaA, A, and Y
-        if (!any(namedglm_g)) {
-            glm_g <- list(DeltaA = glm_g, A = glm_g, DeltaY = glm_g)
-        }
+      # if the SL_g$DeltaA is of length > 1, then call SuperLearner
+      if (length(SL_g$DeltaA) > 1 | is.list(SL_g$DeltaA)) {
+        fm_DeltaA <- SuperLearner::SuperLearner(
+          Y = trainDeltaA,
+          X = trainW, newX = validW, family = stats::binomial(),
+          SL.library = SL_g$DeltaA, verbose = verbose,
+          method = "method.CC_nloglik_mod"
+        )
+        # get predicted probability of missing treatment
+        gn_DeltaA <- fm_DeltaA$SL.predict
+      } else if (!is.list(SL_g$DeltaA) & length(SL_g$DeltaA) == 1) {
+        fm_DeltaA <- do.call(SL_g$DeltaA, args = list(
+          Y = trainDeltaA,
+          X = trainW, newX = validW,
+          obsWeights = rep(1, length(trainA)),
+          family = stats::binomial()
+        ))
+        gn_DeltaA <- fm_DeltaA$pred
+      }
+    } # end if SuperLearner loop
+    if (!is.null(glm_g)) {
+      thisDat <- data.frame(DeltaA = trainDeltaA, trainW)
+      fm_DeltaA <- stats::glm(stats::as.formula(paste0(
+        "DeltaA~",
+        glm_g$DeltaA
+      )), data = thisDat, family = stats::binomial())
+      gn_DeltaA <- stats::predict(
+        fm_DeltaA, type = "response",
+        newdata = data.frame(DeltaA = validDeltaA, validW)
+      )
     }
-    
-    #-------------------------------
-    # regression of DeltaA ~ W
-    #-------------------------------
-    # only fit this regression if there are some missing treatment assignments
-    if (!all(DeltaA == 1)) {
-        # if super learner library is specified, fit a super learner
-        if (!is.null(SL_g)) 
-            {
-                # if the SL_g$DeltaA is of length > 1, then call SuperLearner
-                if (length(SL_g$DeltaA) > 1 | is.list(SL_g$DeltaA)) {
-                  fm_DeltaA <- SuperLearner::SuperLearner(Y = trainDeltaA, 
-                    X = trainW, newX = validW, family = stats::binomial(), 
-                    SL.library = SL_g$DeltaA, verbose = verbose, 
-                    method = "method.CC_nloglik_mod")
-                  # get predicted probability of missing treatment
-                  gn_DeltaA <- fm_DeltaA$SL.predict
-                } else if (!is.list(SL_g$DeltaA) & length(SL_g$DeltaA) == 1) {
-                  fm_DeltaA <- do.call(SL_g$DeltaA, args = list(Y = trainDeltaA, 
-                    X = trainW, newX = validW, 
-                    obsWeights = rep(1, length(trainA)), 
-                    family = stats::binomial()))
-                  gn_DeltaA <- fm_DeltaA$pred
-                }
-            }  # end if SuperLearner loop
-        if (!is.null(glm_g)) {
-            thisDat <- data.frame(DeltaA = trainDeltaA, trainW)
-            fm_DeltaA <- stats::glm(stats::as.formula(paste0("DeltaA~", 
-                glm_g$DeltaA)), data = thisDat, family = stats::binomial())
-            gn_DeltaA <- stats::predict(fm_DeltaA, type = "response",
-                newdata = data.frame(DeltaA = validDeltaA, validW))
+    # name for returned models
+    name_DeltaA <- "DeltaA ~ W"
+  } else {
+    # if all DeltaA==1 then put NULL model and 1 predictions
+    fm_DeltaA <- NULL
+    name_DeltaA <- ""
+    gn_DeltaA <- rep(1, length(validDeltaA))
+  }
+
+  # -----------------------------------
+  # fitting A ~ W | DeltaA = 1
+  # -----------------------------------
+  # if a super learner library is specified, fit the super learner
+  if (!is.null(SL_g)) {
+    # if the library is of length > 1, then call SuperLearner
+    if (length(SL_g$A) > 1 | is.list(SL_g$A)) {
+      # if there are only two unique values of A, then only need one fit
+      if (length(a_0) == length(unique(A)) &
+        length(unique(A[!is.na(A)])) == 2) {
+        fm_A <- SuperLearner::SuperLearner(
+          Y = as.numeric(trainA[trainDeltaA == 1] == a_0[1]),
+          X = trainW[trainDeltaA == 1, , drop = FALSE], newX = validW,
+          family = stats::binomial(), SL.library = SL_g$A,
+          verbose = verbose, method = "method.CC_nloglik_mod"
+        )
+        gn_A <- vector(mode = "list", length = 2)
+        gn_A[[1]] <- fm_A$SL.predict
+        gn_A[[2]] <- 1 - gn_A[[1]]
+        # name for this model
+        name_A <- paste0("I(A = ", a_0[1], ") ~ W | DeltaA == 1")
+        # if there are more than two unique values of A, then we need
+        # more than one call to super learner
+      } else {
+        a_ct <- 0
+        gn_A <- vector(mode = "list", length = length(a_0))
+        fm_A <- vector(mode = "list", length = length(a_0) - 1)
+        name_A <- rep(NA, length(a_0) - 1)
+        for (a in a_0[1:(length(a_0) - 1)]) {
+          # determine who to include in the regression for this outcome
+          if (a_ct == 0) {
+            include <- rep(TRUE, length(trainA))
+          } else {
+            include <- !(trainA %in% a_0[1:a_ct])
+          }
+          # now exclude people with DeltaA = 0
+          include[trainDeltaA == 0] <- FALSE
+          # fit super learner
+          tmp_fm <- SuperLearner::SuperLearner(
+            Y = as.numeric(trainA[include] == a),
+            X = trainW[include, , drop = FALSE], newX = validW,
+            family = stats::binomial(), SL.library = SL_g$A,
+            verbose = verbose
+          )
+          # get predictions
+          tmp_pred <- tmp_fm$SL.pred
+          if (a_ct != 0) {
+            gn_A[[a_ct + 1]] <- tmp_pred * Reduce(
+              "*",
+              lapply(gn_A[1:a_ct], function(x) {
+                1 - x
+              })
+            )
+          } else {
+            gn_A[[a_ct + 1]] <- tmp_pred
+          }
+          fm_A[[a_ct + 1]] <- tmp_fm
+          name_A[a_ct + 1] <- paste0("I(A = ", a, ") ~ W | DeltaA == 1")
+          a_ct <- a_ct + 1
         }
-        # name for returned models
-        name_DeltaA <- "DeltaA ~ W"
+        # add in final predictions
+        gn_A[[a_ct + 1]] <- 1 - Reduce("+", gn_A[1:a_ct])
+      }
+    } else if (!is.list(SL_g$A) & length(SL_g$A) == 1) {
+      if (length(a_0) == length(unique(A[!is.na(A)])) &
+        length(unique(A[!is.na(A)])) == 2) {
+        gn_A <- vector(mode = "list", length = 2)
+        fm_A <- do.call(SL_g$A, args = list(
+          Y = as.numeric(
+            trainA[trainDeltaA == 1] == a_0[1]
+          ),
+          X = trainW[trainDeltaA == 1, , drop = FALSE], newX = validW,
+          obsWeights = rep(1, length(trainA[trainDeltaA == 1])),
+          family = stats::binomial()
+        ))
+        gn_A[[1]] <- fm_A$pred
+        gn_A[[2]] <- 1 - fm_A$pred
+        name_A <- paste0("I(A = ", a_0[1], ") ~ W | DeltaA == 1")
+      } else {
+        a_ct <- 0
+        gn_A <- vector(mode = "list", length = length(a_0))
+        fm_A <- vector(mode = "list", length = length(a_0) - 1)
+        name_A <- rep(NA, length(a_0) - 1)
+        for (a in a_0[1:(length(a_0) - 1)]) {
+          # determine who to include in the regression for this outcome
+          if (a_ct == 0) {
+            include <- rep(TRUE, length(trainA))
+          } else {
+            include <- !(trainA %in% a_0[1:a_ct])
+          }
+          # set missing treatment people to FALSE
+          include[trainDeltaA == 0] <- FALSE
+          # fit super learner
+          tmp_fm <- do.call(SL_g$A, args = list(
+            Y = as.numeric(
+              trainA[include] == a
+            ), X = trainW[include, , drop = FALSE],
+            newX = validW, obsWeights = rep(1, length(trainA[include])),
+            family = stats::binomial()
+          ))
+          # get predictions
+          tmp_pred <- tmp_fm$pred
+          if (a_ct != 0) {
+            gn_A[[a_ct + 1]] <- tmp_pred * Reduce(
+              "*",
+              lapply(gn_A[1:a_ct], function(x) {
+                1 - x
+              })
+            )
+          } else {
+            gn_A[[a_ct + 1]] <- tmp_pred
+          }
+          fm_A[[a_ct + 1]] <- tmp_fm
+          name_A[a_ct + 1] <- paste0("I(A = ", a, ") ~ W | DeltaA == 1")
+          a_ct <- a_ct + 1
+        }
+        # add in final predictions
+        gn_A[[a_ct + 1]] <- 1 - Reduce("+", gn_A[1:a_ct])
+      }
+    }
+  }
+  # ----------------------------------------------------------------------
+  # GLM
+  # ----------------------------------------------------------------------
+  if (!is.null(glm_g)) {
+    if (length(a_0) == length(unique(A)) &
+      length(unique(A[!is.na(A)])) == 2) {
+      thisDat <- data.frame(A = as.numeric(trainA[trainDeltaA == 1] ==
+        a_0[1]), trainW[trainDeltaA == 1, , drop = FALSE])
+      fm_A <- stats::glm(
+        stats::as.formula(paste0("A~", glm_g$A)),
+        data = thisDat, family = stats::binomial()
+      )
+      gn_A <- vector(mode = "list", length = 2)
+      name_A <- paste0("I(A = ", a_0[1], ") ~ W | DeltaA == 1")
+      gn_A[[1]] <- stats::predict(fm_A, newdata = data.frame(
+        A = validA, validW
+      ), type = "response")
+      gn_A[[2]] <- 1 - gn_A[[1]]
     } else {
-        # if all DeltaA==1 then put NULL model and 1 predictions
-        fm_DeltaA <- NULL
-        name_DeltaA <- ""
-        gn_DeltaA <- rep(1, length(validDeltaA))
-    }
-    
-    #-----------------------------------
-    # fitting A ~ W | DeltaA = 1
-    #-----------------------------------  
-    # if a super learner library is specified, fit the super learner
+      a_ct <- 0
+      gn_A <- vector(mode = "list", length = length(a_0))
+      fm_A <- vector(mode = "list", length = length(a_0) - 1)
+      name_A <- rep(NA, length(a_0) - 1)
+      for (a in a_0[1:(length(a_0) - 1)]) {
+        # determine who to include in the regression for this outcome
+        if (a_ct == 0) {
+          include <- rep(TRUE, length(A))
+        } else {
+          include <- !(A %in% a_0[1:a_ct])
+        }
+        # don't include folks with missing treatment
+        include[trainDeltaA == 0] <- FALSE
+        # fit super learner
+        thisDat <- data.frame(
+          as.numeric(trainA[include] == a),
+          trainW[include, , drop = FALSE]
+        )
+        colnames(thisDat) <- c("A", colnames(W))
+        tmp_fm <- stats::glm(
+          stats::as.formula(paste0("A~", glm_g)),
+          data = thisDat, family = stats::binomial()
+        )
+        tmp_pred <- stats::predict(tmp_fm, newdata = data.frame(
+          A = validA, validW
+        ), type = "response")
+        # get predictions
+        if (a_ct != 0) {
+          gn_A[[a_ct + 1]] <- tmp_pred * Reduce(
+            "*",
+            lapply(gn_A[1:a_ct], function(x) {
+              1 - x
+            })
+          )
+        } else {
+          gn_A[[a_ct + 1]] <- tmp_pred
+        }
+        fm_A[[a_ct + 1]] <- tmp_fm
+        name_A[a_ct + 1] <- paste0("I(A = ", a, ") ~ W | DeltaA == 1")
+        a_ct <- a_ct + 1
+      } # end for loop over treatment levels
+      # add in final predictions
+      gn_A[[a_ct + 1]] <- 1 - Reduce("+", gn_A[1:a_ct])
+    } # end multi-level treatment if
+  } # end glm_g if
+
+  # -------------------------------------
+  # fit DeltaY ~ W + A | DeltaA = 1
+  # -------------------------------------
+  # only fit this regression if there are some missing outcomes
+  if (!all(DeltaY == 1)) {
+    # only include people with DeltaA == 1
+    include <- (trainDeltaA == 1)
+
+    # if super learner library is specified, fit a super learner
     if (!is.null(SL_g)) {
-        # if the library is of length > 1, then call SuperLearner
-        if (length(SL_g$A) > 1 | is.list(SL_g$A)) {
-            # if there are only two unique values of A, then only need one fit
-            if (length(a_0) == length(unique(A)) & 
-                length(unique(A[!is.na(A)])) == 2) {
-                fm_A <- SuperLearner::SuperLearner(
-                  Y = as.numeric(trainA[trainDeltaA == 1] == a_0[1]), 
-                  X = trainW[trainDeltaA == 1, , drop = FALSE], newX = validW, 
-                  family = stats::binomial(), SL.library = SL_g$A, 
-                  verbose = verbose, method = "method.CC_nloglik_mod")
-                gn_A <- vector(mode = "list", length = 2)
-                gn_A[[1]] <- fm_A$SL.predict
-                gn_A[[2]] <- 1 - gn_A[[1]]
-                # name for this model
-                name_A <- paste0("I(A = ", a_0[1], ") ~ W | DeltaA == 1")
-                # if there are more than two unique values of A, then we need 
-                # more than one call to super learner
-            } else {
-                a_ct <- 0
-                gn_A <- vector(mode = "list", length = length(a_0))
-                fm_A <- vector(mode = "list", length = length(a_0) - 1)
-                name_A <- rep(NA, length(a_0) - 1)
-                for (a in a_0[1:(length(a_0) - 1)]) {
-                  # determine who to include in the regression for this outcome
-                  if (a_ct == 0) {
-                    include <- rep(TRUE, length(trainA))
-                  } else {
-                    include <- !(trainA %in% a_0[1:a_ct])
-                  }
-                  # now exclude people with DeltaA = 0
-                  include[trainDeltaA == 0] <- FALSE
-                  # fit super learner
-                  tmp_fm <- SuperLearner::SuperLearner(
-                    Y = as.numeric(trainA[include] == a), 
-                    X = trainW[include, , drop = FALSE], newX = validW, 
-                    family = stats::binomial(), SL.library = SL_g$A, 
-                    verbose = verbose)
-                  # get predictions
-                  tmp_pred <- tmp_fm$SL.pred
-                  if (a_ct != 0) {
-                    gn_A[[a_ct + 1]] <- tmp_pred * Reduce("*", 
-                      lapply(gn_A[1:a_ct], function(x) { 1 - x }))
-                  } else {
-                    gn_A[[a_ct + 1]] <- tmp_pred
-                  }
-                  fm_A[[a_ct + 1]] <- tmp_fm
-                  name_A[a_ct + 1] <- paste0("I(A = ", a, ") ~ W | DeltaA == 1")
-                  a_ct <- a_ct + 1
-                }
-                # add in final predictions
-                gn_A[[a_ct + 1]] <- 1 - Reduce("+", gn_A[1:a_ct])
-            }
-        } else if (!is.list(SL_g$A) & length(SL_g$A) == 1) {
-            if (length(a_0) == length(unique(A[!is.na(A)])) & 
-                length(unique(A[!is.na(A)])) == 2) {
-                gn_A <- vector(mode = "list", length = 2)
-                fm_A <- do.call(SL_g$A, args = list(Y = as.numeric(
-                  trainA[trainDeltaA == 1] == a_0[1]), 
-                  X = trainW[trainDeltaA == 1, , drop = FALSE], newX = validW, 
-                  obsWeights = rep(1, length(trainA[trainDeltaA == 1])), 
-                  family = stats::binomial()))
-                gn_A[[1]] <- fm_A$pred
-                gn_A[[2]] <- 1 - fm_A$pred
-                name_A <- paste0("I(A = ", a_0[1], ") ~ W | DeltaA == 1")
-            } else {
-                a_ct <- 0
-                gn_A <- vector(mode = "list", length = length(a_0))
-                fm_A <- vector(mode = "list", length = length(a_0) - 1)
-                name_A <- rep(NA, length(a_0) - 1)
-                for (a in a_0[1:(length(a_0) - 1)]) {
-                  # determine who to include in the regression for this outcome
-                  if (a_ct == 0) {
-                    include <- rep(TRUE, length(trainA))
-                  } else {
-                    include <- !(trainA %in% a_0[1:a_ct])
-                  }
-                  # set missing treatment people to FALSE
-                  include[trainDeltaA == 0] <- FALSE
-                  # fit super learner
-                  tmp_fm <- do.call(SL_g$A, args = list(Y = as.numeric(
-                    trainA[include] == a), X = trainW[include, , drop = FALSE], 
-                    newX = validW, obsWeights = rep(1, length(trainA[include])), 
-                    family = stats::binomial()))
-                  # get predictions
-                  tmp_pred <- tmp_fm$pred
-                  if (a_ct != 0) {
-                    gn_A[[a_ct + 1]] <- tmp_pred * Reduce("*", 
-                      lapply(gn_A[1:a_ct], function(x) { 1 - x }))
-                  } else {
-                    gn_A[[a_ct + 1]] <- tmp_pred
-                  }
-                  fm_A[[a_ct + 1]] <- tmp_fm
-                  name_A[a_ct + 1] <- paste0("I(A = ", a, ") ~ W | DeltaA == 1")
-                  a_ct <- a_ct + 1
-                }
-                # add in final predictions
-                gn_A[[a_ct + 1]] <- 1 - Reduce("+", gn_A[1:a_ct])
-            }
-        }
-    }
-    #----------------------------------------------------------------------
-    # GLM
-    #----------------------------------------------------------------------
-    if (!is.null(glm_g)) 
-        {
-            if (length(a_0) == length(unique(A)) & 
-                length(unique(A[!is.na(A)])) == 2) {
-                thisDat <- data.frame(A = as.numeric(trainA[trainDeltaA == 1] == 
-                  a_0[1]), trainW[trainDeltaA == 1, , drop = FALSE])
-                fm_A <- stats::glm(stats::as.formula(paste0("A~", glm_g$A)), 
-                  data = thisDat, family = stats::binomial())
-                gn_A <- vector(mode = "list", length = 2)
-                name_A <- paste0("I(A = ", a_0[1], ") ~ W | DeltaA == 1")
-                gn_A[[1]] <- stats::predict(fm_A, newdata = data.frame(
-                  A = validA, validW), type = "response")
-                gn_A[[2]] <- 1 - gn_A[[1]]
-            } else {
-                a_ct <- 0
-                gn_A <- vector(mode = "list", length = length(a_0))
-                fm_A <- vector(mode = "list", length = length(a_0) - 1)
-                name_A <- rep(NA, length(a_0) - 1)
-                for (a in a_0[1:(length(a_0) - 1)]) {
-                  # determine who to include in the regression for this outcome
-                  if (a_ct == 0) {
-                    include <- rep(TRUE, length(A))
-                  } else {
-                    include <- !(A %in% a_0[1:a_ct])
-                  }
-                  # don't include folks with missing treatment
-                  include[trainDeltaA == 0] <- FALSE
-                  # fit super learner
-                  thisDat <- data.frame(as.numeric(trainA[include] == a), 
-                    trainW[include, , drop = FALSE])
-                  colnames(thisDat) <- c("A", colnames(W))
-                  tmp_fm <- stats::glm(stats::as.formula(paste0("A~", glm_g)), 
-                    data = thisDat, family = stats::binomial())
-                  tmp_pred <- stats::predict(tmp_fm, newdata = data.frame(
-                    A = validA, validW), type = "response")
-                  # get predictions
-                  if (a_ct != 0) {
-                    gn_A[[a_ct + 1]] <- tmp_pred * Reduce("*", 
-                      lapply(gn_A[1:a_ct], function(x) { 1 - x }))
-                  } else {
-                    gn_A[[a_ct + 1]] <- tmp_pred
-                  }
-                  fm_A[[a_ct + 1]] <- tmp_fm
-                  name_A[a_ct + 1] <- paste0("I(A = ", a, ") ~ W | DeltaA == 1")
-                  a_ct <- a_ct + 1
-                }  # end for loop over treatment levels
-                # add in final predictions
-                gn_A[[a_ct + 1]] <- 1 - Reduce("+", gn_A[1:a_ct])
-            }  # end multi-level treatment if
-        }  # end glm_g if
-    
-    #-------------------------------------
-    # fit DeltaY ~ W + A | DeltaA = 1
-    #-------------------------------------
-    # only fit this regression if there are some missing outcomes
-    if (!all(DeltaY == 1)) {
-        # only include people with DeltaA == 1
-        include <- (trainDeltaA == 1)
-        
-        # if super learner library is specified, fit a super learner
-        if (!is.null(SL_g)) 
-            {
-                # if the SL_g$DeltaY is of length > 1, then call SuperLearner
-                if (length(SL_g$DeltaY) > 1 | is.list(SL_g$DeltaY)) {
-                  # if no stratify, then fit DeltaY ~ W | DeltaA = 1 in each 
-                  # level of A
-                  if (stratify) {
-                    fm_DeltaY <- vector(mode = "list", length = length(a_0))
-                    gn_DeltaY <- vector(mode = "list", length = length(a_0))
-                    name_DeltaY <- rep(NA, length(a_0))
-                    a_ct <- 0
-                    for (a in a_0) {
-                      a_ct <- a_ct + 1
-                      
-                      # only include people with A == a and DeltaA == 1
-                      include2 <- (trainA == a)
-                      include2[is.na(include2)] <- FALSE
-                      
-                      # fit super learner
-                      fm_DeltaY[[a_ct]] <- SuperLearner::SuperLearner(
-                        Y = trainDeltaY[include & include2], 
-                        X = trainW[include & include2, , drop = FALSE], 
-                        newX = validW, family = stats::binomial(), 
-                        SL.library = SL_g$DeltaY, verbose = verbose, 
-                        method = "method.CC_nloglik_mod")
-                      # name the fit
-                      name_DeltaY[a_ct] <- paste0("DeltaY ~ W | DeltaA == 1",
-                        " & A == ", a)
-                      # get predictions back on everybody
-                      gn_DeltaY[[a_ct]] <- fm_DeltaY[[a_ct]]$SL.predict
-                    }  # end loop over treatment levels
-                    # if not stratified, fit a single regression pooling over 
-                    # levels of A
-                  } else {
-                    # fit super learner
-                    fm_DeltaY <- SuperLearner::SuperLearner(
-                      Y = trainDeltaY[include], X = data.frame(
-                        A = trainA[include], trainW[include, , drop = FALSE]), 
-                      family = stats::binomial(), SL.library = SL_g$DeltaY, 
-                      verbose = verbose, method = "method.CC_nloglik_mod")
-                    
-                    # get predictions back setting A = a for every a in a_0
-                    gn_DeltaY <- vector(mode = "list", length = length(a_0))
-                    name_DeltaY <- paste0("DeltaY ~ W + A | DeltaA == 1")
-                    a_ct <- 0
-                    for (a in a_0) {
-                      a_ct <- a_ct + 1
-                      gn_DeltaY[[a_ct]] <- stats::predict(fm_DeltaY, 
-                        onlySL = TRUE, newdata = data.frame(A = a, validW))$pred
-                    }
-                  }  # end if !stratify
-                  # if SL_g$DeltaY only a single algorithm, then call directly
-                } else if (!is.list(SL_g$DeltaY) & length(SL_g$DeltaY) == 1) 
-                  {
-                    # if no stratify, then fit DeltaY ~ W | DeltaA = 1 in 
-                    # each level of A
-                    if (stratify) {
-                      fm_DeltaY <- vector(mode = "list", length = length(a_0))
-                      gn_DeltaY <- vector(mode = "list", length = length(a_0))
-                      name_DeltaY <- rep(NA, length(a_0))
-                      a_ct <- 0
-                      for (a in a_0) {
-                        a_ct <- a_ct + 1
-                        
-                        # only include people with A == a
-                        include2 <- (trainA == a)
-                        include2[is.na(include2)] <- FALSE
-                        # make call to algorithm
-                        fm_DeltaY[[a_ct]] <- do.call(SL_g$DeltaY, args = list(
-                            Y = trainDeltaY[include & include2], 
-                            X = trainW[include & include2, , drop = FALSE], 
-                            newX = validW, obsWeights = rep(1, 
-                              length(trainA[include & include2])), 
-                            family = stats::binomial()))
-                        name_DeltaY[a_ct] <- paste0("DeltaY ~ W | DeltaA == 1",
-                          " & A == ", a)
-                        # get predictions
-                        gn_DeltaY[[a_ct]] <- fm_DeltaY[[a_ct]]$pred
-                      }  # end loop over a_0
-                    } else {
-                      # end if stratify call algorithm to fit pooled estimate
-                      fm_DeltaY <- do.call(SL_g$DeltaY, args = list(
-                          Y = trainDeltaY[include], 
-                          X = data.frame(A = trainA[include], 
-                            trainW[include, , drop = FALSE]), newX = data.frame(
-                          A = validA, validW), obsWeights = rep(1, 
-                          length(trainA[include])), family = stats::binomial()))
-                      name_DeltaY <- paste0("DeltaY ~ W + A | DeltaA == 1")
-                      # loop to get predictions setting A = a
-                      gn_DeltaY <- vector(mode = "list", length = length(a_0))
-                      a_ct <- 0
-                      for (a in a_0) {
-                        a_ct <- a_ct + 1
-                        gn_DeltaY[[a_ct]] <- stats::predict(fm_DeltaY$fit, 
-                          newdata = data.frame(A = a, validW))
-                      }
-                    }  # end !stratify
-                  }  # end if one algorithm loop
-            }  # end SL_g not null if
-        if (!is.null(glm_g)) 
-            {
-                if (stratify) {
-                  fm_DeltaY <- vector(mode = "list", length = length(a_0))
-                  gn_DeltaY <- vector(mode = "list", length = length(a_0))
-                  name_DeltaY <- rep(NA, length = length(a_0))
-                  a_ct <- 0
-                  for (a in a_0) {
-                    a_ct <- a_ct + 1
-                    
-                    # only include people with A == a and DeltaA == 1
-                    include2 <- (trainA == a)
-                    include2[is.na(include2)] <- FALSE
-                    fm_DeltaY[[a_ct]] <- stats::glm(stats::as.formula(
-                        paste0("trainDeltaY[include & include2]~", 
-                      glm_g$DeltaY)), data = data.frame(trainW[include & 
-                        include2, , drop = FALSE]), family = stats::binomial())
-                    name_DeltaY[a_ct] <- paste0("DeltaY ~ W | DeltaA == 1 ", 
-                      "& A == ", a)
-                    # get predictions back for everyone
-                    gn_DeltaY[[a_ct]] <- stats::predict(fm_DeltaY[[a_ct]], 
-                      newdata = validW, type = "response")
-                  }  # end loop over treatments
-                } else {
-                  # end stratified glm fit glm in everyone with DeltaA == 1
-                  fm_DeltaY <- stats::glm(stats::as.formula(paste0(
-                      "trainDeltaY[include]~", glm_g$DeltaY)), 
-                    data = data.frame(A = trainA[include], trainW[include, 
-                      , drop = FALSE]), family = stats::binomial())
-                  name_DeltaY <- paste0("DeltaY ~ W + A | DeltaA == 1")
-                  # get predictions back setting A = a
-                  gn_DeltaY <- vector(mode = "list", length = length(a_0))
-                  a_ct <- 0
-                  for (a in a_0) {
-                    a_ct <- a_ct + 1
-                    gn_DeltaY[[a_ct]] <- stats::predict(fm_DeltaY, 
-                      newdata = data.frame(A = a, validW), type = "response")
-                  }  # end loop over treatments
-                }  # end !stratified glm
-            }  # end glm if
-    } else {
-        # if all DeltaY==1 then NULL model and 1 pred.
-        fm_DeltaY <- NULL
-        name_DeltaY <- ""
+      # if the SL_g$DeltaY is of length > 1, then call SuperLearner
+      if (length(SL_g$DeltaY) > 1 | is.list(SL_g$DeltaY)) {
+        # if no stratify, then fit DeltaY ~ W | DeltaA = 1 in each
+        # level of A
+        if (stratify) {
+          fm_DeltaY <- vector(mode = "list", length = length(a_0))
+          gn_DeltaY <- vector(mode = "list", length = length(a_0))
+          name_DeltaY <- rep(NA, length(a_0))
+          a_ct <- 0
+          for (a in a_0) {
+            a_ct <- a_ct + 1
+
+            # only include people with A == a and DeltaA == 1
+            include2 <- (trainA == a)
+            include2[is.na(include2)] <- FALSE
+
+            # fit super learner
+            fm_DeltaY[[a_ct]] <- SuperLearner::SuperLearner(
+              Y = trainDeltaY[include & include2],
+              X = trainW[include & include2, , drop = FALSE],
+              newX = validW, family = stats::binomial(),
+              SL.library = SL_g$DeltaY, verbose = verbose,
+              method = "method.CC_nloglik_mod"
+            )
+            # name the fit
+            name_DeltaY[a_ct] <- paste0(
+              "DeltaY ~ W | DeltaA == 1",
+              " & A == ", a
+            )
+            # get predictions back on everybody
+            gn_DeltaY[[a_ct]] <- fm_DeltaY[[a_ct]]$SL.predict
+          } # end loop over treatment levels
+          # if not stratified, fit a single regression pooling over
+          # levels of A
+        } else {
+          # fit super learner
+          fm_DeltaY <- SuperLearner::SuperLearner(
+            Y = trainDeltaY[include], X = data.frame(
+              A = trainA[include], trainW[include, , drop = FALSE]
+            ),
+            family = stats::binomial(), SL.library = SL_g$DeltaY,
+            verbose = verbose, method = "method.CC_nloglik_mod"
+          )
+
+          # get predictions back setting A = a for every a in a_0
+          gn_DeltaY <- vector(mode = "list", length = length(a_0))
+          name_DeltaY <- paste0("DeltaY ~ W + A | DeltaA == 1")
+          a_ct <- 0
+          for (a in a_0) {
+            a_ct <- a_ct + 1
+            gn_DeltaY[[a_ct]] <- stats::predict(
+              fm_DeltaY,
+              onlySL = TRUE, newdata = data.frame(A = a, validW)
+            )$pred
+          }
+        } # end if !stratify
+        # if SL_g$DeltaY only a single algorithm, then call directly
+      } else if (!is.list(SL_g$DeltaY) & length(SL_g$DeltaY) == 1) {
+        # if no stratify, then fit DeltaY ~ W | DeltaA = 1 in
+        # each level of A
+        if (stratify) {
+          fm_DeltaY <- vector(mode = "list", length = length(a_0))
+          gn_DeltaY <- vector(mode = "list", length = length(a_0))
+          name_DeltaY <- rep(NA, length(a_0))
+          a_ct <- 0
+          for (a in a_0) {
+            a_ct <- a_ct + 1
+
+            # only include people with A == a
+            include2 <- (trainA == a)
+            include2[is.na(include2)] <- FALSE
+            # make call to algorithm
+            fm_DeltaY[[a_ct]] <- do.call(SL_g$DeltaY, args = list(
+              Y = trainDeltaY[include & include2],
+              X = trainW[include & include2, , drop = FALSE],
+              newX = validW, obsWeights = rep(
+                1,
+                length(trainA[include & include2])
+              ),
+              family = stats::binomial()
+            ))
+            name_DeltaY[a_ct] <- paste0(
+              "DeltaY ~ W | DeltaA == 1",
+              " & A == ", a
+            )
+            # get predictions
+            gn_DeltaY[[a_ct]] <- fm_DeltaY[[a_ct]]$pred
+          } # end loop over a_0
+        } else {
+          # end if stratify call algorithm to fit pooled estimate
+          fm_DeltaY <- do.call(SL_g$DeltaY, args = list(
+            Y = trainDeltaY[include],
+            X = data.frame(
+              A = trainA[include],
+              trainW[include, , drop = FALSE]
+            ), newX = data.frame(
+              A = validA, validW
+            ), obsWeights = rep(
+              1,
+              length(trainA[include])
+            ), family = stats::binomial()
+          ))
+          name_DeltaY <- paste0("DeltaY ~ W + A | DeltaA == 1")
+          # loop to get predictions setting A = a
+          gn_DeltaY <- vector(mode = "list", length = length(a_0))
+          a_ct <- 0
+          for (a in a_0) {
+            a_ct <- a_ct + 1
+            gn_DeltaY[[a_ct]] <- stats::predict(
+              fm_DeltaY$fit,
+              newdata = data.frame(A = a, validW)
+            )
+          }
+        } # end !stratify
+      } # end if one algorithm loop
+    } # end SL_g not null if
+    if (!is.null(glm_g)) {
+      if (stratify) {
+        fm_DeltaY <- vector(mode = "list", length = length(a_0))
         gn_DeltaY <- vector(mode = "list", length = length(a_0))
-        for (i in 1:length(a_0)) {
-            gn_DeltaY[[i]] <- rep(1, length(validDeltaY))
-        }
+        name_DeltaY <- rep(NA, length = length(a_0))
+        a_ct <- 0
+        for (a in a_0) {
+          a_ct <- a_ct + 1
+
+          # only include people with A == a and DeltaA == 1
+          include2 <- (trainA == a)
+          include2[is.na(include2)] <- FALSE
+          fm_DeltaY[[a_ct]] <- stats::glm(stats::as.formula(
+            paste0(
+              "trainDeltaY[include & include2]~",
+              glm_g$DeltaY
+            )
+          ), data = data.frame(trainW[include &
+            include2, , drop = FALSE]), family = stats::binomial())
+          name_DeltaY[a_ct] <- paste0(
+            "DeltaY ~ W | DeltaA == 1 ",
+            "& A == ", a
+          )
+          # get predictions back for everyone
+          gn_DeltaY[[a_ct]] <- stats::predict(
+            fm_DeltaY[[a_ct]],
+            newdata = validW, type = "response"
+          )
+        } # end loop over treatments
+      } else {
+        # end stratified glm fit glm in everyone with DeltaA == 1
+        fm_DeltaY <- stats::glm(
+          stats::as.formula(paste0(
+            "trainDeltaY[include]~", glm_g$DeltaY
+          )),
+          data = data.frame(A = trainA[include], trainW[
+            include,
+            , drop = FALSE
+          ]), family = stats::binomial()
+        )
+        name_DeltaY <- paste0("DeltaY ~ W + A | DeltaA == 1")
+        # get predictions back setting A = a
+        gn_DeltaY <- vector(mode = "list", length = length(a_0))
+        a_ct <- 0
+        for (a in a_0) {
+          a_ct <- a_ct + 1
+          gn_DeltaY[[a_ct]] <- stats::predict(
+            fm_DeltaY,
+            newdata = data.frame(A = a, validW), type = "response"
+          )
+        } # end loop over treatments
+      } # end !stratified glm
+    } # end glm if
+  } else {
+    # if all DeltaY==1 then NULL model and 1 pred.
+    fm_DeltaY <- NULL
+    name_DeltaY <- ""
+    gn_DeltaY <- vector(mode = "list", length = length(a_0))
+    for (i in 1:length(a_0)) {
+      gn_DeltaY[[i]] <- rep(1, length(validDeltaY))
     }
-    
-    #------------------------------------------------------
-    # combine estimates into a single propensity score
-    #------------------------------------------------------
-    gn <- mapply(gn_A = gn_A, gn_DeltaY = gn_DeltaY, FUN = function(gn_A, 
-      gn_DeltaY) { gn_A * gn_DeltaY * gn_DeltaA }, SIMPLIFY = FALSE)
-    
-    # truncate too-small predictions
-    gn <- lapply(gn, function(g) { g[g < tolg] <- tolg; g })
-    
-    out <- list(est = gn, fm = NULL)
-    if (returnModels) {
-        names(fm_A) <- name_A
-        if (!is.null(fm_DeltaA)) {
-            names(fm_DeltaA) <- name_DeltaA
-        }
-        if (!is.null(fm_DeltaY)) {
-            names(fm_DeltaY) <- name_DeltaY
-        }
-        out$fm <- list(DeltaA = fm_DeltaA, A = fm_A, DeltaY = fm_DeltaY)
+  }
+
+  # ------------------------------------------------------
+  # combine estimates into a single propensity score
+  # ------------------------------------------------------
+  gn <- mapply(gn_A = gn_A, gn_DeltaY = gn_DeltaY, FUN = function(gn_A,
+                                                                  gn_DeltaY) {
+    gn_A * gn_DeltaY * gn_DeltaA
+  }, SIMPLIFY = FALSE)
+
+  # truncate too-small predictions
+  gn <- lapply(gn, function(g) {
+    g[g < tolg] <- tolg
+    g
+  })
+
+  out <- list(est = gn, fm = NULL)
+  if (returnModels) {
+    names(fm_A) <- name_A
+    if (!is.null(fm_DeltaA)) {
+      names(fm_DeltaA) <- name_DeltaA
     }
-    return(out)
+    if (!is.null(fm_DeltaY)) {
+      names(fm_DeltaY) <- name_DeltaY
+    }
+    out$fm <- list(DeltaA = fm_DeltaA, A = fm_A, DeltaY = fm_DeltaY)
+  }
+  return(out)
 }
 
 
 
-#' estimateQ 
-#' 
+#' estimateQ
+#'
 #' Function to estimate initial outcome regression
-#' 
-#' @param Y A vector of continuous or binary outcomes. 
-#' @param A A vector of binary treatment assignment (assumed to be equal to 0 or 
+#'
+#' @param Y A vector of continuous or binary outcomes.
+#' @param A A vector of binary treatment assignment (assumed to be equal to 0 or
 #' 1).
 #' @param W A \code{data.frame} of named covariates.
-#' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if 
+#' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if
 #' missing 1 if observed).
-#' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if 
+#' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if
 #' missing 1 if observed).
-#' @param SL_Q A vector of characters or a list describing the Super Learner 
+#' @param SL_Q A vector of characters or a list describing the Super Learner
 #' library to be used for the outcome regression.
 #' @param verbose A boolean indicating whether to print status updates.
-#' @param returnModels A boolean indicating whether to return model fits for the 
+#' @param returnModels A boolean indicating whether to return model fits for the
 #' outcome regression, propensity score, and reduced-dimension regressions.
-#' @param glm_Q A character describing a formula to be used in the call to 
+#' @param glm_Q A character describing a formula to be used in the call to
 #' \code{glm} for the outcome regression.
-#' @param a_0 A list of fixed treatment values 
+#' @param a_0 A list of fixed treatment values
 #' @param family A character passed to \code{SuperLearner}
-#' @param stratify A \code{boolean} indicating whether to estimate the outcome 
-#' regression separately for observations with \code{A} equal to 0/1 (if 
+#' @param stratify A \code{boolean} indicating whether to estimate the outcome
+#' regression separately for observations with \code{A} equal to 0/1 (if
 #' \code{TRUE}) or to pool across \code{A} (if \code{FALSE}).
-#' @param validRows A \code{list} of length \code{cvFolds} containing the row 
+#' @param validRows A \code{list} of length \code{cvFolds} containing the row
 #' indexes of observations to include in validation fold.
-#' @param ... Additional arguments (not currently used) 
-#' 
+#' @param ... Additional arguments (not currently used)
+#'
 #' @importFrom SuperLearner SuperLearner trimLogit
 #' @importFrom stats predict glm as.formula
-#' 
-estimateQ <- function(Y, A, W, DeltaA, DeltaY, SL_Q, glm_Q, a_0, stratify, 
-              family, verbose = FALSE, returnModels = FALSE, validRows = NULL, 
-              ...) {
-    if (is.null(SL_Q) & is.null(glm_Q)) {
-        stop("Specify Super Learner library or GLM formula for Q")
-    }
-    if (!is.null(SL_Q) & !is.null(glm_Q)) {
-        warning(paste0("Super Learner library and GLM formula specified.", 
-          " Proceeding with Super Learner only."))
-        glm_Q <- NULL
-    }
-    # subset data into training and validation sets
-    if (length(validRows) != length(Y)) {
-        trainY <- Y[-validRows]
-        trainA <- A[-validRows]
-        trainW <- W[-validRows, , drop = FALSE]
-        trainDeltaA <- DeltaA[-validRows]
-        trainDeltaY <- DeltaY[-validRows]
-        validW <- W[validRows, , drop = FALSE]
-        validA <- A[validRows]
-        validY <- Y[validRows]
-        validDeltaY <- DeltaY[validRows]
-        validDeltaA <- DeltaA[validRows]
+#'
+estimateQ <- function(Y, A, W, DeltaA, DeltaY, SL_Q, glm_Q, a_0, stratify,
+                      family, verbose = FALSE, returnModels = FALSE, validRows = NULL,
+                      ...) {
+  if (is.null(SL_Q) & is.null(glm_Q)) {
+    stop("Specify Super Learner library or GLM formula for Q")
+  }
+  if (!is.null(SL_Q) & !is.null(glm_Q)) {
+    warning(paste0(
+      "Super Learner library and GLM formula specified.",
+      " Proceeding with Super Learner only."
+    ))
+    glm_Q <- NULL
+  }
+  # subset data into training and validation sets
+  if (length(validRows) != length(Y)) {
+    trainY <- Y[-validRows]
+    trainA <- A[-validRows]
+    trainW <- W[-validRows, , drop = FALSE]
+    trainDeltaA <- DeltaA[-validRows]
+    trainDeltaY <- DeltaY[-validRows]
+    validW <- W[validRows, , drop = FALSE]
+    validA <- A[validRows]
+    validY <- Y[validRows]
+    validDeltaY <- DeltaY[validRows]
+    validDeltaA <- DeltaA[validRows]
+  } else {
+    trainA <- validA <- A
+    trainW <- validW <- W
+    trainY <- validY <- Y
+    trainDeltaA <- validDeltaA <- DeltaA
+    trainDeltaY <- validDeltaY <- DeltaY
+  }
+
+  # include only DeltaA = 1 and DeltaY = 1 folks
+  include <- (trainDeltaA == 1) & (trainDeltaY == 1)
+
+  # Super Learner
+  if (!is.null(SL_Q)) {
+    if (!stratify) {
+      if (length(SL_Q) > 1 | is.list(SL_Q)) {
+        fm <- SuperLearner::SuperLearner(
+          Y = trainY[include],
+          X = data.frame(A = trainA, trainW)[include, , drop = FALSE],
+          verbose = verbose, family = family, SL.library = SL_Q,
+          method = ifelse(family$family == "binomial",
+            "method.CC_nloglik_mod", "method.CC_LS_mod"
+          )
+        )
+
+        Qn <- alply(a_0, 1, function(x) {
+          stats::predict(
+            fm, newdata = data.frame(A = x, validW),
+            onlySL = TRUE
+          )[[1]]
+        })
+      } else if (length(SL_Q) == 1) {
+        fm <- do.call(SL_Q, args = list(
+          Y = trainY[include],
+          X = data.frame(A = trainA, trainW)[include, , drop = FALSE],
+          verbose = verbose, newX = data.frame(A = validA, validW),
+          obsWeights = rep(1, length(trainA[include])),
+          family = family
+        ))
+        Qn <- alply(a_0, 1, function(x) {
+          stats::predict(object = fm$fit, newdata = data.frame(
+            A = x,
+            validW
+          ))
+        })
+      }
     } else {
-        trainA <- validA <- A
-        trainW <- validW <- W
-        trainY <- validY <- Y
-        trainDeltaA <- validDeltaA <- DeltaA
-        trainDeltaY <- validDeltaY <- DeltaY
+      if (length(SL_Q) > 1 | is.list(SL_Q)) {
+        tmp <- plyr::alply(a_0, 1, function(x) {
+          include2 <- trainA == x
+          # handle NAs properly
+          include2[is.na(include2)] <- FALSE
+          fm <- SuperLearner::SuperLearner(
+            Y = trainY[include2 & include],
+            X = trainW[include2 & include, , drop = FALSE],
+            newX = validW, verbose = verbose, family = family,
+            SL.library = SL_Q, method = ifelse(family$family ==
+              "binomial", "method.CC_nloglik_mod", "method.CC_LS_mod")
+          )
+          list(est = fm$SL.predict, fm = fm)
+        })
+        Qn <- lapply(tmp, "[[", 1)
+        fm <- lapply(tmp, "[[", 2)
+      } else if (length(SL_Q) == 1) {
+        tmp <- plyr::alply(a_0, 1, function(x) {
+          include2 <- trainA == x
+          # handle NAs properly
+          include2[is.na(include2)] <- FALSE
+          # call function
+          fm <- do.call(SL_Q, args = list(
+            Y = trainY[include2 & include],
+            X = trainW[include2 & include, , drop = FALSE],
+            newX = validW, verbose = verbose,
+            obsWeights = rep(1, sum(include2 & include)),
+            family = family
+          ))
+          list(est = fm$pred, fm = fm)
+        })
+        Qn <- lapply(tmp, "[[", 1)
+        fm <- lapply(tmp, "[[", 2)
+      }
     }
-    
-    # include only DeltaA = 1 and DeltaY = 1 folks
-    include <- (trainDeltaA == 1) & (trainDeltaY == 1)
-    
-    # Super Learner
-    if (!is.null(SL_Q)) {
-        if (!stratify) {
-            if (length(SL_Q) > 1 | is.list(SL_Q)) {
-                fm <- SuperLearner::SuperLearner(Y = trainY[include], 
-                  X = data.frame(A = trainA, trainW)[include, , drop = FALSE], 
-                  verbose = verbose, family = family, SL.library = SL_Q, 
-                  method = ifelse(family$family == "binomial", 
-                    "method.CC_nloglik_mod", "method.CC_LS_mod"))
-                
-                Qn <- alply(a_0, 1, function(x) {
-                  stats::predict(fm, newdata = data.frame(A = x, validW), 
-                    onlySL = TRUE)[[1]]
-                })
-            } else if (length(SL_Q) == 1) {
-                fm <- do.call(SL_Q, args = list(Y = trainY[include], 
-                    X = data.frame(A = trainA, trainW)[include, , drop = FALSE], 
-                    verbose = verbose, newX = data.frame(A = validA, validW), 
-                    obsWeights = rep(1, length(trainA[include])), 
-                    family = family))
-                Qn <- alply(a_0, 1, function(x) {
-                  stats::predict(object = fm$fit, newdata = data.frame(A = x, 
-                      validW))
-                })
-            }
-        } else {
-            if (length(SL_Q) > 1 | is.list(SL_Q)) {
-                tmp <- plyr::alply(a_0, 1, function(x) {
-                  include2 <- trainA == x
-                  # handle NAs properly
-                  include2[is.na(include2)] <- FALSE
-                  fm <- SuperLearner::SuperLearner(
-                    Y = trainY[include2 & include], 
-                    X = trainW[include2 & include, , drop = FALSE], 
-                    newX = validW, verbose = verbose, family = family, 
-                    SL.library = SL_Q, method = ifelse(family$family == 
-                      "binomial", "method.CC_nloglik_mod", "method.CC_LS_mod"))
-                  list(est = fm$SL.predict, fm = fm)
-                })
-                Qn <- lapply(tmp, "[[", 1)
-                fm <- lapply(tmp, "[[", 2)
-            } else if (length(SL_Q) == 1) {
-                tmp <- plyr::alply(a_0, 1, function(x) {
-                  include2 <- trainA == x
-                  # handle NAs properly
-                  include2[is.na(include2)] <- FALSE
-                  # call function
-                  fm <- do.call(SL_Q, args = list(
-                      Y = trainY[include2 & include], 
-                      X = trainW[include2 & include, , drop = FALSE], 
-                      newX = validW, verbose = verbose, 
-                      obsWeights = rep(1, sum(include2 & include)), 
-                      family = family))
-                  list(est = fm$pred, fm = fm)
-                })
-                Qn <- lapply(tmp, "[[", 1)
-                fm <- lapply(tmp, "[[", 2)
-            }
-        }
+  }
+
+  # GLM
+  if (!is.null(glm_Q)) {
+    if (!stratify) {
+      fm <- stats::glm(
+        stats::as.formula(paste0("Y~", glm_Q)),
+        data = data.frame(Y = trainY, A = trainA, trainW)[
+          include, ,
+          drop = FALSE
+        ], family = family
+      )
+      Qn <- plyr::alply(matrix(a_0), 1, function(a, fm) {
+        stats::predict(
+          fm, newdata = data.frame(A = a, validW),
+          type = "response"
+        )
+      }, fm = fm)
+    } else {
+      tmp <- plyr::alply(matrix(a_0), 1, function(a) {
+        include2 <- trainA == a
+        # handle NAs properly
+        include2[is.na(include2)] <- FALSE
+        fm <- stats::glm(
+          stats::as.formula(paste0(
+            "trainY[include2 & include] ~ ", glm_Q
+          )),
+          data = trainW[include2 & include, , drop = FALSE],
+          family = family
+        )
+        return(list(est = stats::predict(
+          fm, newdata = validW,
+          type = "response"
+        ), fm = fm))
+      })
+      Qn <- lapply(tmp, "[[", 1)
+      fm <- lapply(tmp, "[[", 2)
     }
-    
-    # GLM
-    if (!is.null(glm_Q)) {
-        if (!stratify) {
-            fm <- stats::glm(stats::as.formula(paste0("Y~", glm_Q)), 
-                data = data.frame(Y = trainY, A = trainA, trainW)[include, , 
-                drop = FALSE], family = family)
-            Qn <- plyr::alply(matrix(a_0), 1, function(a, fm) {
-                stats::predict(fm, newdata = data.frame(A = a, validW), 
-                  type = "response")
-            }, fm = fm)
-        } else {
-            tmp <- plyr::alply(matrix(a_0), 1, function(a) {
-                include2 <- trainA == a
-                # handle NAs properly
-                include2[is.na(include2)] <- FALSE
-                fm <- stats::glm(stats::as.formula(paste0(
-                  "trainY[include2 & include] ~ ", glm_Q)), 
-                  data = trainW[include2 & include, , drop = FALSE], 
-                  family = family)
-                return(list(est = stats::predict(fm, newdata = validW, 
-                    type = "response"), fm = fm))
-            })
-            Qn <- lapply(tmp, "[[", 1)
-            fm <- lapply(tmp, "[[", 2)
-        }
-    }
-    out <- list(est = Qn, fm = NULL)
-    if (returnModels) 
-        out$fm <- fm
-    return(out)
+  }
+  out <- list(est = Qn, fm = NULL)
+  if (returnModels) {
+    out$fm <- fm
+  }
+  return(out)
 }
 
-#' estimateQrn 
-#' 
-#' Estimates the reduced dimension regressions necessary for the  
+#' estimateQrn
+#'
+#' Estimates the reduced dimension regressions necessary for the
 #' fluctuations of g
-#' 
-#' 
-#' @param Y A vector of continuous or binary outcomes. 
+#'
+#'
+#' @param Y A vector of continuous or binary outcomes.
 #' @param A A vector of binary treatment assignment (assumed to be equal to 0 or
 #'  1)
 #' @param W A \code{data.frame} of named covariates
-#' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if 
+#' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if
 #' missing 1 if observed)
-#' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if 
+#' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if
 #' missing 1 if observed)
-#' @param Qn A list of outcome regression estimates evaluated on observed data. 
-#' If NULL then 0 is used for all Qn (as is needed to estimate reduced dimension 
+#' @param Qn A list of outcome regression estimates evaluated on observed data.
+#' If NULL then 0 is used for all Qn (as is needed to estimate reduced dimension
 #' regression for adaptive_iptw)
-#' @param gn A list of propensity regression estimates evaluated on observed 
+#' @param gn A list of propensity regression estimates evaluated on observed
 #' data
-#' @param SL_Qr A vector of characters or a list describing the Super Learner 
+#' @param SL_Qr A vector of characters or a list describing the Super Learner
 #' library to be used for the first reduced-dimension regression.
-#' @param glm_Qr A character describing a formula to be used in the call to 
-#' \code{glm} for the first reduced-dimension regression. Ignored if 
+#' @param glm_Qr A character describing a formula to be used in the call to
+#' \code{glm} for the first reduced-dimension regression. Ignored if
 #' \code{SL_gr!=NULL}.
 #' @param a_0 A list of fixed treatment values.
-#' @param returnModels A boolean indicating whether to return model fits for the 
+#' @param returnModels A boolean indicating whether to return model fits for the
 #' outcome regression, propensity score, and reduced-dimension regressions.
-#' @param family Should be gaussian() unless called from adaptive_iptw with 
+#' @param family Should be gaussian() unless called from adaptive_iptw with
 #' binary \code{Y}.
-#' @param validRows A \code{list} of length \code{cvFolds} containing the row 
+#' @param validRows A \code{list} of length \code{cvFolds} containing the row
 #' indexes of observations to include in validation fold.
 #' @importFrom SuperLearner SuperLearner trimLogit
 #' @importFrom stats predict glm as.formula gaussian binomial
 
-estimateQrn <- function(Y, A, W, DeltaA, DeltaY, Qn, gn, glm_Qr, SL_Qr, 
-                family = stats::gaussian(), a_0, returnModels, validRows = NULL) 
-{
-    
-    # if estimateQrn is called in adaptive_iptw, then Qn will enter as NULL. 
-    # Here we fill its value to 0 so that we estimate the correct nuisance 
-    # parameter for adaptive_iptw
-    if (is.null(Qn)) {
-        Qn <- vector(mode = "list", length = length(a_0))
-        for (i in 1:length(a_0)) {
-            Qn[[i]] <- rep(0, length(Y))
+estimateQrn <- function(Y, A, W, DeltaA, DeltaY, Qn, gn, glm_Qr, SL_Qr,
+                        family = stats::gaussian(), a_0, returnModels, validRows = NULL) {
+
+  # if estimateQrn is called in adaptive_iptw, then Qn will enter as NULL.
+  # Here we fill its value to 0 so that we estimate the correct nuisance
+  # parameter for adaptive_iptw
+  if (is.null(Qn)) {
+    Qn <- vector(mode = "list", length = length(a_0))
+    for (i in 1:length(a_0)) {
+      Qn[[i]] <- rep(0, length(Y))
+    }
+  }
+
+  # subset data into training and validation sets
+  if (length(validRows) != length(Y)) {
+    trainY <- Y[-validRows]
+    trainA <- A[-validRows]
+    trainW <- W[-validRows, , drop = FALSE]
+    trainDeltaA <- DeltaA[-validRows]
+    trainDeltaY <- DeltaY[-validRows]
+    train_gn <- lapply(gn, "[", -validRows)
+    train_Qn <- lapply(Qn, "[", -validRows)
+    validW <- W[validRows, , drop = FALSE]
+    validA <- A[validRows]
+    validY <- Y[validRows]
+    validDeltaA <- DeltaA[-validRows]
+    validDeltaY <- DeltaY[-validRows]
+    valid_gn <- lapply(gn, "[", validRows)
+    valid_Qn <- lapply(Qn, "[", validRows)
+  } else {
+    trainA <- validA <- A
+    trainW <- validW <- W
+    trainY <- validY <- Y
+    trainDeltaY <- validDeltaY <- DeltaY
+    trainDeltaA <- validDeltaA <- DeltaA
+    train_gn <- valid_gn <- gn
+    train_Qn <- valid_Qn <- Qn
+  }
+
+  if (is.null(SL_Qr) & is.null(glm_Qr)) {
+    stop("Specify Super Learner library or GLM formula for Qr")
+  }
+  if (!is.null(SL_Qr) & !is.null(glm_Qr)) {
+    warning(paste0(
+      "Super Learner library and GLM formula specified.",
+      "Proceeding with Super Learner only."
+    ))
+    glm_Qr <- NULL
+  }
+  # Super Learner
+  if (!is.null(SL_Qr)) {
+    Qrn <- mapply(
+      a = a_0, train_g = train_gn, train_Q = train_Qn,
+      valid_g = valid_gn, valid_Q = valid_Qn, SIMPLIFY = FALSE,
+      FUN = function(a, train_g, train_Q, valid_g, valid_Q) {
+        Aeqa <- trainA == a
+        Aeqa[is.na(Aeqa)] <- FALSE
+        if (length(unique(train_g)) == 1) {
+          warning(paste0(
+            "Only one unique value of gn", a,
+            ". Using empirical average as Qr estimate."
+          ))
+          m1 <- mean((trainY - train_Q)[Aeqa & trainDeltaA == 1 &
+            trainDeltaY == 1])
+          est <- rep(m1, length(validY))
+          fm <- list(fit = list(object = m1), pred = NULL)
+          class(fm$fit) <- "SL.mean"
+        } else {
+          if (length(SL_Qr) > 1) {
+            suppressWarnings(fm <- SuperLearner::SuperLearner(
+              Y = (trainY - train_Q)[Aeqa & trainDeltaA == 1 &
+                trainDeltaY == 1], X = data.frame(gn = train_g[Aeqa &
+                trainDeltaA == 1 & trainDeltaY == 1]), newX = data.frame(
+                gn = valid_g
+              ), family = family, SL.library = SL_Qr,
+              method = "method.CC_LS_mod"
+            ))
+            # if all weights = 0, use discrete SL
+            if (!all(fm$coef == 0)) {
+              est <- fm$SL.predict
+            } else {
+              est <- fm$library.predict[, which.min(fm$cvRisk)]
+            }
+          } else if (length(SL_Qr) == 1) {
+            fm <- do.call(SL_Qr, args = list(
+              Y = (trainY - train_Q)[Aeqa & trainDeltaA == 1 &
+                trainDeltaY == 1], X = data.frame(gn = train_g[Aeqa &
+                trainDeltaA == 1 & trainDeltaY == 1]),
+              family = family, newX = data.frame(gn = valid_g),
+              obsWeights = rep(1, length(trainY[Aeqa &
+                trainDeltaA == 1 & trainDeltaY == 1]))
+            ))
+            est <- fm$pred
+          }
         }
-    }
-    
-    # subset data into training and validation sets
-    if (length(validRows) != length(Y)) {
-        trainY <- Y[-validRows]
-        trainA <- A[-validRows]
-        trainW <- W[-validRows, , drop = FALSE]
-        trainDeltaA <- DeltaA[-validRows]
-        trainDeltaY <- DeltaY[-validRows]
-        train_gn <- lapply(gn, "[", -validRows)
-        train_Qn <- lapply(Qn, "[", -validRows)
-        validW <- W[validRows, , drop = FALSE]
-        validA <- A[validRows]
-        validY <- Y[validRows]
-        validDeltaA <- DeltaA[-validRows]
-        validDeltaY <- DeltaY[-validRows]
-        valid_gn <- lapply(gn, "[", validRows)
-        valid_Qn <- lapply(Qn, "[", validRows)
-    } else {
-        trainA <- validA <- A
-        trainW <- validW <- W
-        trainY <- validY <- Y
-        trainDeltaY <- validDeltaY <- DeltaY
-        trainDeltaA <- validDeltaA <- DeltaA
-        train_gn <- valid_gn <- gn
-        train_Qn <- valid_Qn <- Qn
-    }
-    
-    if (is.null(SL_Qr) & is.null(glm_Qr)) {
-        stop("Specify Super Learner library or GLM formula for Qr")
-    }
-    if (!is.null(SL_Qr) & !is.null(glm_Qr)) {
-        warning(paste0("Super Learner library and GLM formula specified.", 
-          "Proceeding with Super Learner only."))
-        glm_Qr <- NULL
-    }
-    # Super Learner
-    if (!is.null(SL_Qr)) {
-        Qrn <- mapply(a = a_0, train_g = train_gn, train_Q = train_Qn, 
-                      valid_g = valid_gn, valid_Q = valid_Qn, SIMPLIFY = FALSE, 
-                      FUN = function(a, train_g, train_Q, valid_g, valid_Q) {
-                Aeqa <- trainA == a
-                Aeqa[is.na(Aeqa)] <- FALSE
-                if (length(unique(train_g)) == 1) {
-                  warning(paste0("Only one unique value of gn", a, 
-                    ". Using empirical average as Qr estimate."))
-                  m1 <- mean((trainY - train_Q)[Aeqa & trainDeltaA == 1 & 
-                                trainDeltaY == 1])
-                  est <- rep(m1, length(validY))
-                  fm <- list(fit = list(object = m1), pred = NULL)
-                  class(fm$fit) <- "SL.mean"
-                } else {
-                  if (length(SL_Qr) > 1) {
-                    suppressWarnings(fm <- SuperLearner::SuperLearner(
-                      Y = (trainY - train_Q)[Aeqa & trainDeltaA == 1 & 
-                        trainDeltaY == 1], X = data.frame(gn = train_g[Aeqa & 
-                      trainDeltaA == 1 & trainDeltaY == 1]), newX = data.frame(
-                        gn = valid_g), family = family, SL.library = SL_Qr, 
-                      method = "method.CC_LS_mod"))
-                    # if all weights = 0, use discrete SL
-                    if (!all(fm$coef == 0)) {
-                      est <- fm$SL.predict
-                    } else {
-                      est <- fm$library.predict[, which.min(fm$cvRisk)]
-                    }
-                  } else if (length(SL_Qr) == 1) {
-                    fm <- do.call(SL_Qr, args = list(
-                        Y = (trainY - train_Q)[Aeqa & trainDeltaA == 1 & 
-                          trainDeltaY == 1], X = data.frame(gn = train_g[Aeqa & 
-                          trainDeltaA == 1 & trainDeltaY == 1]), 
-                        family = family, newX = data.frame(gn = valid_g), 
-                        obsWeights = rep(1, length(trainY[Aeqa & 
-                          trainDeltaA == 1 & trainDeltaY == 1]))))
-                    est <- fm$pred
-                  }
-                }
-                out <- list(est = est, fm = NULL)
-                if (returnModels) 
-                  out$fm <- fm
-                return(out)
-            })
-    }
-    
-    # GLM
-    if (!is.null(glm_Qr)) {
-        Qrn <- mapply(a = a_0, train_g = train_gn, train_Q = train_Qn, 
-                valid_g = valid_gn, valid_Q = valid_Qn, SIMPLIFY = FALSE, 
-                FUN = function(a, train_g, train_Q, valid_g, valid_Q) {
-                  Aeqa <- trainA == a
-                  Aeqa[is.na(Aeqa)] <- FALSE
-                  if (length(unique(train_g)) == 1) {
-                    warning(paste0("Only one unique value of gn", a, 
-                      ". Using empirical average as Qr estimate."))
-                    glm_Qr <- "1"
-                  }
-                  fm <- stats::glm(stats::as.formula(paste0("Qrn ~", glm_Qr)), 
-                    data = data.frame(Qrn = (trainY - train_Q)[Aeqa & 
-                        trainDeltaY == 1 & trainDeltaY == 1], 
-                      gn = train_g[Aeqa & trainDeltaY == 1 & trainDeltaY == 1]), 
-                    family = family)
-                  est <- stats::predict(fm, newdata = data.frame(gn = valid_g), 
-                    type = "response")
-                  out <- list(est = est, fm = NULL)
-                  if (returnModels) 
-                    out$fm <- fm
-                  return(out)
-            })
-    }
-    # return estimates and models
-    return(list(est = lapply(Qrn, function(x) {
-        x$est
-    }), fm = lapply(Qrn, function(x) {
-        fm = x$fm
-    })))
-    Qrn
+        out <- list(est = est, fm = NULL)
+        if (returnModels) {
+          out$fm <- fm
+        }
+        return(out)
+      }
+    )
+  }
+
+  # GLM
+  if (!is.null(glm_Qr)) {
+    Qrn <- mapply(
+      a = a_0, train_g = train_gn, train_Q = train_Qn,
+      valid_g = valid_gn, valid_Q = valid_Qn, SIMPLIFY = FALSE,
+      FUN = function(a, train_g, train_Q, valid_g, valid_Q) {
+        Aeqa <- trainA == a
+        Aeqa[is.na(Aeqa)] <- FALSE
+        if (length(unique(train_g)) == 1) {
+          warning(paste0(
+            "Only one unique value of gn", a,
+            ". Using empirical average as Qr estimate."
+          ))
+          glm_Qr <- "1"
+        }
+        fm <- stats::glm(
+          stats::as.formula(paste0("Qrn ~", glm_Qr)),
+          data = data.frame(
+            Qrn = (trainY - train_Q)[Aeqa &
+              trainDeltaY == 1 & trainDeltaY == 1],
+            gn = train_g[Aeqa & trainDeltaY == 1 & trainDeltaY == 1]
+          ),
+          family = family
+        )
+        est <- stats::predict(
+          fm, newdata = data.frame(gn = valid_g),
+          type = "response"
+        )
+        out <- list(est = est, fm = NULL)
+        if (returnModels) {
+          out$fm <- fm
+        }
+        return(out)
+      }
+    )
+  }
+  # return estimates and models
+  return(list(est = lapply(Qrn, function(x) {
+    x$est
+  }), fm = lapply(Qrn, function(x) {
+    fm <- x$fm
+  })))
+  Qrn
 }
 
-#' estimategrn 
-#' 
-#' Estimates the reduced dimension regressions necessary for the additional 
-#' fluctuations. 
-#' 
-#' @param Y A vector of continuous or binary outcomes. 
+#' estimategrn
+#'
+#' Estimates the reduced dimension regressions necessary for the additional
+#' fluctuations.
+#'
+#' @param Y A vector of continuous or binary outcomes.
 #' @param A A vector of binary treatment assignment (assumed to be equal to 0 or
 #'  1).
 #' @param W A \code{data.frame} of named covariates.
-#' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if 
+#' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if
 #' missing 1 if observed).
-#' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if 
+#' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if
 #' missing 1 if observed).
 #' @param Qn A list of outcome regression estimates evaluated on observed data.
-#' @param gn A list of propensity regression estimates evaluated on observed 
+#' @param gn A list of propensity regression estimates evaluated on observed
 #' data.
-#' @param SL_gr A vector of characters or a list describing the Super Learner 
+#' @param SL_gr A vector of characters or a list describing the Super Learner
 #' library to be used for the reduced-dimension propensity score.
-#' @param glm_gr A character describing a formula to be used in the call to 
-#' \code{glm} for the second reduced-dimension regression. Ignored if 
+#' @param glm_gr A character describing a formula to be used in the call to
+#' \code{glm} for the second reduced-dimension regression. Ignored if
 #' \code{SL_gr!=NULL}.
-#' @param reduction A character equal to \code{'univariate'} for a univariate 
-#' misspecification correction or \code{'bivariate'} for the bivariate version. 
-#' @param tolg A numeric indicating the minimum value for estimates of the 
+#' @param reduction A character equal to \code{'univariate'} for a univariate
+#' misspecification correction or \code{'bivariate'} for the bivariate version.
+#' @param tolg A numeric indicating the minimum value for estimates of the
 #' propensity score.
 #' @param a_0 A list of fixed treatment values .
-#' @param returnModels A boolean indicating whether to return model fits for the 
+#' @param returnModels A boolean indicating whether to return model fits for the
 #' outcome regression, propensity score, and reduced-dimension regressions.
-#' @param validRows A \code{list} of length \code{cvFolds} containing the row 
+#' @param validRows A \code{list} of length \code{cvFolds} containing the row
 #' indexes of observations to include in validation fold.
-#' 
+#'
 #' @importFrom SuperLearner SuperLearner trimLogit
 #' @importFrom stats predict glm as.formula
 
-estimategrn <- function(Y, A, W, DeltaA, DeltaY, Qn, gn, SL_gr, tolg, glm_gr, 
-    a_0, reduction, returnModels, validRows) {
-    if (length(validRows) != length(Y)) {
-        trainY <- Y[-validRows]
-        trainA <- A[-validRows]
-        trainW <- W[-validRows, , drop = FALSE]
-        trainDeltaA <- DeltaA[-validRows]
-        trainDeltaY <- DeltaY[-validRows]
-        train_gn <- lapply(gn, "[", -validRows)
-        train_Qn <- lapply(Qn, "[", -validRows)
-        validW <- W[validRows, , drop = FALSE]
-        validA <- A[validRows]
-        validY <- Y[validRows]
-        validDeltaA <- DeltaA[-validRows]
-        validDeltaY <- DeltaY[-validRows]
-        valid_gn <- lapply(gn, "[", validRows)
-        valid_Qn <- lapply(Qn, "[", validRows)
-    } else {
-        trainA <- validA <- A
-        trainW <- validW <- W
-        trainY <- validY <- Y
-        trainDeltaY <- validDeltaY <- DeltaY
-        trainDeltaA <- validDeltaA <- DeltaA
-        train_gn <- valid_gn <- gn
-        train_Qn <- valid_Qn <- Qn
-    }
-    
-    if (is.null(SL_gr) & is.null(glm_gr)) {
-        stop("Specify Super Learner library or GLM formula for gr")
-    }
-    if (!is.null(SL_gr) & !is.null(glm_gr)) {
-        warning(paste0("Super Learner library and GLM formula specified.", 
-          "Proceeding with Super Learner only."))
-        glm_gr <- NULL
-    }
-    # Super Learner
-    if (!is.null(SL_gr)) {
-        grn <- mapply(a = a_0, train_Q = train_Qn, train_g = train_gn, 
-              valid_Q = valid_Qn, valid_g = valid_gn, SIMPLIFY = FALSE, 
-              FUN = function(a, train_Q, train_g, valid_Q, valid_g) {
-                Aeqa <- trainA == a
-                Aeqa[is.na(Aeqa)] <- FALSE
-                if (length(unique(train_Q)) == 1) {
-                  warning(paste0("Only one unique value of Qn.", 
-                      "Proceeding with empirical mean for grn"))
-                  if (reduction == "univariate") {
-                    m1 <- mean((as.numeric(Aeqa & trainDeltaA == 1 & 
-                      trainDeltaY == 1) - train_g)/train_g)
-                    grn1 <- rep(m1, length(validY))
-                    m2 <- mean(as.numeric(Aeqa & trainDeltaA == 1 & 
-                      trainDeltaY == 1))
-                    grn2 <- rep(m2, length(validY))
-                    grn2[grn2 < tolg] <- tolg
-                    fm1 <- list(fit = list(object = m1), pred = NULL)
-                    class(fm1$fit) <- "SL.mean"
-                    fm2 <- list(fit = list(object = m2), pred = NULL)
-                    class(fm2$fit) <- "SL.mean"
-                  } else if (reduction == "bivariate") {
-                    m2 <- mean(as.numeric(Aeqa & trainDeltaA == 1 & 
-                      trainDeltaY == 1))
-                    grn2 <- rep(m2, length(validY))
-                    grn2[grn2 < tolg] <- tolg
-                    fm2 <- list(fit = list(object = m2), pred = NULL)
-                    class(fm2$fit) <- "SL.mean"
-                    fm1 <- NULL
-                    grn1 <- rep(NA, length(validY))
-                  }
-                } else {
-                  if (length(SL_gr) > 1) {
-                    if (reduction == "univariate") {
-                      fm1 <- SuperLearner::SuperLearner(
-                        Y = (as.numeric(Aeqa & trainDeltaA == 1 & 
-                              trainDeltaY == 1) - train_g)/train_g, 
-                        X = data.frame(Qn = train_Q), 
-                        newX = data.frame(Qn = valid_Q), 
-                        family = stats::gaussian(), SL.library = SL_gr, 
-                        method = "method.CC_LS_mod")
-                      fm2 <- SuperLearner::SuperLearner(Y = as.numeric(Aeqa & 
-                          trainDeltaA == 1 & trainDeltaY == 1), 
-                        X = data.frame(Qn = train_Q), 
-                        newX = data.frame(Qn = valid_Q), 
-                        family = stats::binomial(), SL.library = SL_gr, 
-                        method = "method.CC_nloglik_mod")
-                      if (!all(fm1$coef == 0)) {
-                        grn1 <- fm1$SL.predict
-                      } else {
-                        grn1 <- fm1$library.predict[, which.min(fm1$cvRisk)]
-                      }
-                      
-                      if (!all(fm2$coef == 0)) {
-                        grn2 <- fm2$SL.predict
-                      } else {
-                        grn2 <- fm2$library.predict[, which.min(fm2$cvRisk)]
-                      }
-                      grn2[grn2 < tolg] <- tolg
-                    } else if (reduction == "bivariate") {
-                      fm2 <- SuperLearner::SuperLearner(Y = as.numeric(Aeqa & 
-                          trainDeltaA == 1 & trainDeltaY == 1), 
-                        X = data.frame(Qn = train_Q, gn = train_g), 
-                        newX = data.frame(Qn = valid_Q, gn = valid_g), 
-                        family = stats::binomial(), 
-                        SL.library = SL_gr, method = "method.CC_nloglik_mod")
-                      if (!all(fm2$coef == 0)) {
-                        grn2 <- fm2$SL.predict
-                      } else {
-                        grn2 <- fm2$library.predict[, which.min(fm2$cvRisk)]
-                      }
-                      grn2[grn2 < tolg] <- tolg
-                      fm1 <- NULL
-                      grn1 <- rep(NA, length(validY))
-                    }
-                  } else if (length(SL_gr) == 1) {
-                    if (reduction == "univariate") {
-                      fm1 <- do.call(SL_gr, args = list(Y = (as.numeric(Aeqa & 
-                        trainDeltaA == 1 & trainDeltaY == 1) - train_g)/train_g, 
-                        X = data.frame(Qn = train_Q), obsWeights = rep(1, 
-                          length(trainA)), newX = data.frame(Qn = valid_Q), 
-                        family = stats::gaussian()))
-                      grn1 <- fm1$pred
-                      fm2 <- do.call(SL_gr, args = list(Y = as.numeric(Aeqa & 
-                        trainDeltaA == 1 & trainDeltaY == 1), 
-                        X = data.frame(Qn = train_Q), obsWeights = rep(1, 
-                          length(trainA)), newX = data.frame(Qn = valid_Q), 
-                        family = stats::binomial()))
-                      grn2 <- fm2$pred
-                      grn2[grn2 < tolg] <- tolg
-                    } else if (reduction == "bivariate") {
-                      fm2 <- do.call(SL_gr, args = list(Y = as.numeric(Aeqa & 
-                        trainDeltaA == 1 & trainDeltaY == 1), 
-                        X = data.frame(Qn = train_Q, gn = train_g), 
-                        obsWeights = rep(1, length(trainA)), 
-                        newX = data.frame(Qn = valid_Q, gn = valid_g), 
-                        family = stats::binomial()))
-                      grn2 <- fm2$pred
-                      grn2[grn2 < tolg] <- tolg
-                      fm1 <- NULL
-                      grn1 <- rep(NA, length(validY))
-                    }
-                  }
-                }
-                out <- list(grn1 = grn1, grn2 = grn2, fm1 = NULL, fm2 = NULL)
-                if (returnModels) {
-                  out$fm1 <- fm1
-                  out$fm2 <- fm2
-                }
-                return(out)
-            })
-    }
-    
-    # GLM
-    if (!is.null(glm_gr)) {
-        grn <- mapply(a = a_0, train_Q = train_Qn, train_g = train_gn, 
-          valid_Q = valid_Qn, valid_g = valid_gn, SIMPLIFY = FALSE, 
-          FUN = function(a, train_Q, train_g, valid_Q, valid_g) {
-                Aeqa <- trainA == a
-                Aeqa[is.na(Aeqa)] <- FALSE
-                
-                if (length(unique(train_Q)) == 1) {
-                  glm_gr <- "1"
-                }
-                if (reduction == "univariate") {
-                  fm1 <- stats::glm(stats::as.formula(paste0("grn1~", glm_gr)), 
-                    family = "gaussian", data = data.frame(grn1 = (as.numeric(
-                      Aeqa & trainDeltaA == 1 & trainDeltaY == 1) - train_g) / 
-                      train_g, Qn = train_Q))
-                  grn1 <- stats::predict(fm1, newdata = data.frame(grn1 = rep(0, 
-                    length(validA)), Qn = valid_Q), type = "response")
-                  fm2 <- stats::glm(stats::as.formula(paste0("A~", glm_gr)), 
-                    family = "binomial", data = data.frame(A = as.numeric(Aeqa & 
-                      trainDeltaY == 1 & trainDeltaA == 1), Qn = train_Q))
-                  grn2 <- stats::predict(fm2, type = "response", newdata = 
-                    data.frame(A = rep(0, length(validA)), Qn = valid_Q))
-                } else if (reduction == "bivariate") {
-                  fm1 <- NULL
-                  grn1 <- rep(NA, length(validY))
-                  fm2 <- stats::glm(stats::as.formula(paste0("A~", glm_gr)), 
-                    family = "binomial", data = data.frame(A = as.numeric(Aeqa & 
-                      trainDeltaY == 1 & trainDeltaA == 1), Qn = train_Q, 
-                    gn = train_g))
-                  grn2 <- stats::predict(fm2, type = "response", 
-                    newdata = data.frame(A = rep(0, length(validA)), 
-                      Qn = valid_Q, gn = valid_g))
-                }
-                grn2[grn2 < tolg] <- tolg
-                out <- list(grn1 = grn1, grn2 = grn2, fm1 = NULL, fm2 = NULL)
-                if (returnModels) {
-                  out$fm1 <- fm1
-                  out$fm2 <- fm2
-                }
-                return(out)
-            })
-    }
-    tmp1 <- lapply(grn, function(x) {
-        data.frame(grn1 = x$grn1, grn2 = x$grn2)
-    })
-    tmp2 <- lapply(grn, function(x) {
-        list(fm1 = x$fm1, fm2 = x$fm2)
-    })
-    return(list(est = tmp1, fm = tmp2))
+estimategrn <- function(Y, A, W, DeltaA, DeltaY, Qn, gn, SL_gr, tolg, glm_gr,
+                        a_0, reduction, returnModels, validRows) {
+  if (length(validRows) != length(Y)) {
+    trainY <- Y[-validRows]
+    trainA <- A[-validRows]
+    trainW <- W[-validRows, , drop = FALSE]
+    trainDeltaA <- DeltaA[-validRows]
+    trainDeltaY <- DeltaY[-validRows]
+    train_gn <- lapply(gn, "[", -validRows)
+    train_Qn <- lapply(Qn, "[", -validRows)
+    validW <- W[validRows, , drop = FALSE]
+    validA <- A[validRows]
+    validY <- Y[validRows]
+    validDeltaA <- DeltaA[-validRows]
+    validDeltaY <- DeltaY[-validRows]
+    valid_gn <- lapply(gn, "[", validRows)
+    valid_Qn <- lapply(Qn, "[", validRows)
+  } else {
+    trainA <- validA <- A
+    trainW <- validW <- W
+    trainY <- validY <- Y
+    trainDeltaY <- validDeltaY <- DeltaY
+    trainDeltaA <- validDeltaA <- DeltaA
+    train_gn <- valid_gn <- gn
+    train_Qn <- valid_Qn <- Qn
+  }
+
+  if (is.null(SL_gr) & is.null(glm_gr)) {
+    stop("Specify Super Learner library or GLM formula for gr")
+  }
+  if (!is.null(SL_gr) & !is.null(glm_gr)) {
+    warning(paste0(
+      "Super Learner library and GLM formula specified.",
+      "Proceeding with Super Learner only."
+    ))
+    glm_gr <- NULL
+  }
+  # Super Learner
+  if (!is.null(SL_gr)) {
+    grn <- mapply(
+      a = a_0, train_Q = train_Qn, train_g = train_gn,
+      valid_Q = valid_Qn, valid_g = valid_gn, SIMPLIFY = FALSE,
+      FUN = function(a, train_Q, train_g, valid_Q, valid_g) {
+        Aeqa <- trainA == a
+        Aeqa[is.na(Aeqa)] <- FALSE
+        if (length(unique(train_Q)) == 1) {
+          warning(paste0(
+            "Only one unique value of Qn.",
+            "Proceeding with empirical mean for grn"
+          ))
+          if (reduction == "univariate") {
+            m1 <- mean((as.numeric(Aeqa & trainDeltaA == 1 &
+              trainDeltaY == 1) - train_g) / train_g)
+            grn1 <- rep(m1, length(validY))
+            m2 <- mean(as.numeric(Aeqa & trainDeltaA == 1 &
+              trainDeltaY == 1))
+            grn2 <- rep(m2, length(validY))
+            grn2[grn2 < tolg] <- tolg
+            fm1 <- list(fit = list(object = m1), pred = NULL)
+            class(fm1$fit) <- "SL.mean"
+            fm2 <- list(fit = list(object = m2), pred = NULL)
+            class(fm2$fit) <- "SL.mean"
+          } else if (reduction == "bivariate") {
+            m2 <- mean(as.numeric(Aeqa & trainDeltaA == 1 &
+              trainDeltaY == 1))
+            grn2 <- rep(m2, length(validY))
+            grn2[grn2 < tolg] <- tolg
+            fm2 <- list(fit = list(object = m2), pred = NULL)
+            class(fm2$fit) <- "SL.mean"
+            fm1 <- NULL
+            grn1 <- rep(NA, length(validY))
+          }
+        } else {
+          if (length(SL_gr) > 1) {
+            if (reduction == "univariate") {
+              fm1 <- SuperLearner::SuperLearner(
+                Y = (as.numeric(Aeqa & trainDeltaA == 1 &
+                  trainDeltaY == 1) - train_g) / train_g,
+                X = data.frame(Qn = train_Q),
+                newX = data.frame(Qn = valid_Q),
+                family = stats::gaussian(), SL.library = SL_gr,
+                method = "method.CC_LS_mod"
+              )
+              fm2 <- SuperLearner::SuperLearner(
+                Y = as.numeric(Aeqa &
+                  trainDeltaA == 1 & trainDeltaY == 1),
+                X = data.frame(Qn = train_Q),
+                newX = data.frame(Qn = valid_Q),
+                family = stats::binomial(), SL.library = SL_gr,
+                method = "method.CC_nloglik_mod"
+              )
+              if (!all(fm1$coef == 0)) {
+                grn1 <- fm1$SL.predict
+              } else {
+                grn1 <- fm1$library.predict[, which.min(fm1$cvRisk)]
+              }
+
+              if (!all(fm2$coef == 0)) {
+                grn2 <- fm2$SL.predict
+              } else {
+                grn2 <- fm2$library.predict[, which.min(fm2$cvRisk)]
+              }
+              grn2[grn2 < tolg] <- tolg
+            } else if (reduction == "bivariate") {
+              fm2 <- SuperLearner::SuperLearner(
+                Y = as.numeric(Aeqa &
+                  trainDeltaA == 1 & trainDeltaY == 1),
+                X = data.frame(Qn = train_Q, gn = train_g),
+                newX = data.frame(Qn = valid_Q, gn = valid_g),
+                family = stats::binomial(),
+                SL.library = SL_gr, method = "method.CC_nloglik_mod"
+              )
+              if (!all(fm2$coef == 0)) {
+                grn2 <- fm2$SL.predict
+              } else {
+                grn2 <- fm2$library.predict[, which.min(fm2$cvRisk)]
+              }
+              grn2[grn2 < tolg] <- tolg
+              fm1 <- NULL
+              grn1 <- rep(NA, length(validY))
+            }
+          } else if (length(SL_gr) == 1) {
+            if (reduction == "univariate") {
+              fm1 <- do.call(SL_gr, args = list(
+                Y = (as.numeric(Aeqa &
+                  trainDeltaA == 1 & trainDeltaY == 1) - train_g) / train_g,
+                X = data.frame(Qn = train_Q), obsWeights = rep(
+                  1,
+                  length(trainA)
+                ), newX = data.frame(Qn = valid_Q),
+                family = stats::gaussian()
+              ))
+              grn1 <- fm1$pred
+              fm2 <- do.call(SL_gr, args = list(
+                Y = as.numeric(Aeqa &
+                  trainDeltaA == 1 & trainDeltaY == 1),
+                X = data.frame(Qn = train_Q), obsWeights = rep(
+                  1,
+                  length(trainA)
+                ), newX = data.frame(Qn = valid_Q),
+                family = stats::binomial()
+              ))
+              grn2 <- fm2$pred
+              grn2[grn2 < tolg] <- tolg
+            } else if (reduction == "bivariate") {
+              fm2 <- do.call(SL_gr, args = list(
+                Y = as.numeric(Aeqa &
+                  trainDeltaA == 1 & trainDeltaY == 1),
+                X = data.frame(Qn = train_Q, gn = train_g),
+                obsWeights = rep(1, length(trainA)),
+                newX = data.frame(Qn = valid_Q, gn = valid_g),
+                family = stats::binomial()
+              ))
+              grn2 <- fm2$pred
+              grn2[grn2 < tolg] <- tolg
+              fm1 <- NULL
+              grn1 <- rep(NA, length(validY))
+            }
+          }
+        }
+        out <- list(grn1 = grn1, grn2 = grn2, fm1 = NULL, fm2 = NULL)
+        if (returnModels) {
+          out$fm1 <- fm1
+          out$fm2 <- fm2
+        }
+        return(out)
+      }
+    )
+  }
+
+  # GLM
+  if (!is.null(glm_gr)) {
+    grn <- mapply(
+      a = a_0, train_Q = train_Qn, train_g = train_gn,
+      valid_Q = valid_Qn, valid_g = valid_gn, SIMPLIFY = FALSE,
+      FUN = function(a, train_Q, train_g, valid_Q, valid_g) {
+        Aeqa <- trainA == a
+        Aeqa[is.na(Aeqa)] <- FALSE
+
+        if (length(unique(train_Q)) == 1) {
+          glm_gr <- "1"
+        }
+        if (reduction == "univariate") {
+          fm1 <- stats::glm(
+            stats::as.formula(paste0("grn1~", glm_gr)),
+            family = "gaussian", data = data.frame(grn1 = (as.numeric(
+              Aeqa & trainDeltaA == 1 & trainDeltaY == 1
+            ) - train_g) /
+              train_g, Qn = train_Q)
+          )
+          grn1 <- stats::predict(fm1, newdata = data.frame(grn1 = rep(
+            0,
+            length(validA)
+          ), Qn = valid_Q), type = "response")
+          fm2 <- stats::glm(
+            stats::as.formula(paste0("A~", glm_gr)),
+            family = "binomial", data = data.frame(A = as.numeric(Aeqa &
+              trainDeltaY == 1 & trainDeltaA == 1), Qn = train_Q)
+          )
+          grn2 <- stats::predict(
+            fm2, type = "response", newdata =
+              data.frame(A = rep(0, length(validA)), Qn = valid_Q)
+          )
+        } else if (reduction == "bivariate") {
+          fm1 <- NULL
+          grn1 <- rep(NA, length(validY))
+          fm2 <- stats::glm(
+            stats::as.formula(paste0("A~", glm_gr)),
+            family = "binomial", data = data.frame(
+              A = as.numeric(Aeqa &
+                trainDeltaY == 1 & trainDeltaA == 1), Qn = train_Q,
+              gn = train_g
+            )
+          )
+          grn2 <- stats::predict(
+            fm2, type = "response",
+            newdata = data.frame(
+              A = rep(0, length(validA)),
+              Qn = valid_Q, gn = valid_g
+            )
+          )
+        }
+        grn2[grn2 < tolg] <- tolg
+        out <- list(grn1 = grn1, grn2 = grn2, fm1 = NULL, fm2 = NULL)
+        if (returnModels) {
+          out$fm1 <- fm1
+          out$fm2 <- fm2
+        }
+        return(out)
+      }
+    )
+  }
+  tmp1 <- lapply(grn, function(x) {
+    data.frame(grn1 = x$grn1, grn2 = x$grn2)
+  })
+  tmp2 <- lapply(grn, function(x) {
+    list(fm1 = x$fm1, fm2 = x$fm2)
+  })
+  return(list(est = tmp1, fm = tmp2))
 }

--- a/R/fluctuate.R
+++ b/R/fluctuate.R
@@ -1,8 +1,8 @@
 #' fluctuateQ1
-#' 
-#' Function called internally by drtmle to perform the first fluctuation 
+#'
+#' Function called internally by drtmle to perform the first fluctuation
 #' of the initial estimator of Q (i.e., solves the original EIF estimating eqn)
-#' 
+#'
 #' @param Y The outcome
 #' @param A The treatment
 #' @param W The covariates
@@ -10,35 +10,40 @@
 #' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if missing 1 if observed)
 #' @param Qn A list of outcome regression estimates evaluated on observed data
 #' @param gn A list of propensity regression estimates evaluated on observed data
-#' @param a_0 A list of fixed treatment values 
-#' 
+#' @param a_0 A list of fixed treatment values
+#'
 #' @importFrom SuperLearner trimLogit
 #' @importFrom stats predict glm
-#' 
+#'
 
-fluctuateQ1 <- function(Y, A, W, DeltaA, DeltaY, Qn, gn, a_0){
-  QnStar <- mapply(a = a_0, Q = Qn, g = gn, FUN = function(x, a, Q, g){
-      l <- min(Y, na.rm = TRUE); u <- max(Y, na.rm = TRUE)
-      Yscale <- (Y - l) / (u - l)
-      off <- SuperLearner::trimLogit((Q - l) / (u - l))
-      H1 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1) / g
-      suppressWarnings(
-      fm <- stats::glm(Yscale ~ -1 + offset(off) + H1, start = 0,
-                data=data.frame(Y = Y, off = off, H1 = H1), family = "binomial")
+fluctuateQ1 <- function(Y, A, W, DeltaA, DeltaY, Qn, gn, a_0) {
+  QnStar <- mapply(a = a_0, Q = Qn, g = gn, FUN = function(x, a, Q, g) {
+    l <- min(Y, na.rm = TRUE)
+    u <- max(Y, na.rm = TRUE)
+    Yscale <- (Y - l) / (u - l)
+    off <- SuperLearner::trimLogit((Q - l) / (u - l))
+    H1 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1) / g
+    suppressWarnings(
+      fm <- stats::glm(
+        Yscale ~ -1 + offset(off) + H1, start = 0,
+        data = data.frame(Y = Y, off = off, H1 = H1), family = "binomial"
       )
-      Qnstar <- stats::predict(fm, type = "response",
-                       newdata = data.frame(off = off, H1 = 1/g)) * (u - l) + l
-      list(est = Qnstar, eps = fm$coef)
-    }, SIMPLIFY=FALSE)
+    )
+    Qnstar <- stats::predict(
+      fm, type = "response",
+      newdata = data.frame(off = off, H1 = 1 / g)
+    ) * (u - l) + l
+    list(est = Qnstar, eps = fm$coef)
+  }, SIMPLIFY = FALSE)
   QnStar
 }
 
 #' fluctuateG
-#' 
-#' Function called internally by drtmle to perform the fluctuation 
+#'
+#' Function called internally by drtmle to perform the fluctuation
 #' of the initial estimator of g (i.e., solves the new estimating eqn that results
 #' from misspecification of Q)
-#' 
+#'
 #' @param Y The outcome
 #' @param A The treatment
 #' @param W The covariates
@@ -49,33 +54,37 @@ fluctuateQ1 <- function(Y, A, W, DeltaA, DeltaY, Qn, gn, a_0){
 #' @param coefTol A tolerance level on the magnitude of the coefficient that flags the
 #' result as potentially the result of numeric instability.
 #' @param tolg The lower bound on propensity score estimates
-#' @param a_0 A list of fixed treatment values 
-#' 
+#' @param a_0 A list of fixed treatment values
+#'
 #' @importFrom SuperLearner trimLogit
 #' @importFrom stats predict glm
-#' 
+#'
 
-fluctuateG <- function(Y, A, W, DeltaY, DeltaA, a_0, gn, Qrn, tolg, coefTol=1e5){
-  gnStar <- mapply(a = a_0, g = gn, Qr = Qrn, FUN = function(x, a, g, Qr){
+fluctuateG <- function(Y, A, W, DeltaY, DeltaA, a_0, gn, Qrn, tolg, coefTol=1e5) {
+  gnStar <- mapply(a = a_0, g = gn, Qr = Qrn, FUN = function(x, a, g, Qr) {
     H1 <- Qr / g
     off <- SuperLearner::trimLogit(g, tolg)
-    thisA <- as.numeric(A == a & DeltaA ==1 & DeltaY == 1)
+    thisA <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1)
     suppressWarnings(
-      fm <- stats::glm(thisA ~ -1 + offset(off) + H1, start = 0,
-                data = data.frame(thisA = thisA, off = off, H1 = H1), 
-                family = "binomial")
-    )
-    if(!fm$converged | abs(fm$coef) > coefTol){
-      suppressWarnings(
-      fm <- stats::glm(thisA ~ -1 + offset(off) + H1,
-                data = data.frame(thisA = thisA, off = off, H1 = H1), 
-                family = "binomial")
+      fm <- stats::glm(
+        thisA ~ -1 + offset(off) + H1, start = 0,
+        data = data.frame(thisA = thisA, off = off, H1 = H1),
+        family = "binomial"
       )
-      if(!fm$converged | abs(fm$coef) > coefTol){
-        # warning("No sane fluctuation found for G this iteration. Check mean of IC.") 
+    )
+    if (!fm$converged | abs(fm$coef) > coefTol) {
+      suppressWarnings(
+        fm <- stats::glm(
+          thisA ~ -1 + offset(off) + H1,
+          data = data.frame(thisA = thisA, off = off, H1 = H1),
+          family = "binomial"
+        )
+      )
+      if (!fm$converged | abs(fm$coef) > coefTol) {
+        # warning("No sane fluctuation found for G this iteration. Check mean of IC.")
       }
     }
-    pred <- stats::predict(fm, type="response")
+    pred <- stats::predict(fm, type = "response")
     pred[pred < tolg] <- tolg
     list(est = pred, eps = fm$coef)
   }, SIMPLIFY = FALSE)
@@ -83,12 +92,12 @@ fluctuateG <- function(Y, A, W, DeltaY, DeltaA, a_0, gn, Qrn, tolg, coefTol=1e5)
 }
 
 
-#' fluctuateQ2 
-#' 
-#' Function called internally by drtmle to perform the second fluctuation 
+#' fluctuateQ2
+#'
+#' Function called internally by drtmle to perform the second fluctuation
 #' of the initial estimator of Q (i.e., solves the new estimating eqn that results
 #' from misspecification of g)
-#' 
+#'
 #' @param Y The outcome
 #' @param A The treatment
 #' @param W The covariates
@@ -99,71 +108,79 @@ fluctuateG <- function(Y, A, W, DeltaY, DeltaA, a_0, gn, Qrn, tolg, coefTol=1e5)
 #' @param grn A list of reduced-dimension regression estimates evaluated on observed data
 #' @param coefTol A tolerance level on the magnitude of the coefficient that flags the
 #' result as potentially the result of numeric instability.
-#' @param reduction A character indicating what reduced dimension regression was used. 
-#' @param a_0 A list of fixed treatment values 
-#' 
+#' @param reduction A character indicating what reduced dimension regression was used.
+#' @param a_0 A list of fixed treatment values
+#'
 #' @importFrom SuperLearner trimLogit
 #' @importFrom stats predict glm
-#' 
+#'
 
 
-fluctuateQ2 <- function(Y, A, W, DeltaY, DeltaA, 
-                        Qn, gn, grn, a_0, reduction, coefTol=1e5){
-  QnStar <- mapply(a = a_0, Q = Qn, g = gn, gr = grn, FUN = function(a, Q, g, gr){
-    l <- min(Y, na.rm = TRUE); u <- max(Y, na.rm = TRUE)
+fluctuateQ2 <- function(Y, A, W, DeltaY, DeltaA,
+                        Qn, gn, grn, a_0, reduction, coefTol=1e5) {
+  QnStar <- mapply(a = a_0, Q = Qn, g = gn, gr = grn, FUN = function(a, Q, g, gr) {
+    l <- min(Y, na.rm = TRUE)
+    u <- max(Y, na.rm = TRUE)
     Yscale <- (Y - l) / (u - l)
     off <- SuperLearner::trimLogit((Q - l) / (u - l))
-    if(reduction == "univariate"){
+    if (reduction == "univariate") {
       H2 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1) / gr$grn2 * gr$grn1
-    }else if(reduction=="bivariate"){
-      H2 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1) / gr$grn2 * 
-                (gr$grn2 - g) / g
+    } else if (reduction == "bivariate") {
+      H2 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1) / gr$grn2 *
+        (gr$grn2 - g) / g
     }
     suppressWarnings(
-      fm <- stats::glm(Yscale ~ -1 + offset(off) + H2, start = 0,
-                data=data.frame(Y = Y, off = off, H2 = H2), family = "binomial")
+      fm <- stats::glm(
+        Yscale ~ -1 + offset(off) + H2, start = 0,
+        data = data.frame(Y = Y, off = off, H2 = H2), family = "binomial"
+      )
     )
-    if(!fm$converged | abs(max(fm$coef)) > coefTol){
+    if (!fm$converged | abs(max(fm$coef)) > coefTol) {
       # if it doesn't converge, try with no starting values
       suppressWarnings(
-        fm <- stats::glm(Yscale ~ -1 + offset(off) + H2, 
-                  data=data.frame(Y = Y, off = off, H2 = H2), 
-                  family = "binomial")
+        fm <- stats::glm(
+          Yscale ~ -1 + offset(off) + H2,
+          data = data.frame(Y = Y, off = off, H2 = H2),
+          family = "binomial"
+        )
       )
-      if(!fm$converged | abs(max(fm$coef)) > coefTol){
+      if (!fm$converged | abs(max(fm$coef)) > coefTol) {
         # warning("No sane fluctuation found. Proceeding using current estimates.")
-        if(reduction == "univariate"){
-          return(list(est = Q, eps = rep(0,2)))
-        }else if(reduction == "bivariate"){
-          return(list(est = Q, eps = rep(0,2)))
+        if (reduction == "univariate") {
+          return(list(est = Q, eps = rep(0, 2)))
+        } else if (reduction == "bivariate") {
+          return(list(est = Q, eps = rep(0, 2)))
         }
       }
     }
-    
-    if(reduction == "univariate"){
+
+    if (reduction == "univariate") {
       Qnstar <- stats::predict(
         fm, type = "response", newdata = data.frame(
-          off=off, H2=1/gr$grn2 * gr$grn1)
-        )*(u-l) + l
+          off = off, H2 = 1 / gr$grn2 * gr$grn1
+        )
+      ) * (u - l) + l
 
       return(list(est = Qnstar, eps = fm$coef))
-    }else if(reduction == "bivariate"){
+    } else if (reduction == "bivariate") {
       Qnstar <- stats::predict(
-        fm, type = "response", newdata = data.frame(off = off, 
-          H2 = 1/gr$grn2 * (gr$grn2-g)/g)
-        )*(u-l) + l
+        fm, type = "response", newdata = data.frame(
+          off = off,
+          H2 = 1 / gr$grn2 * (gr$grn2 - g) / g
+        )
+      ) * (u - l) + l
       return(list(est = Qnstar, eps = fm$coef))
     }
   }, SIMPLIFY = FALSE)
   QnStar
 }
 
-#' fluctuateQ 
-#' 
-#' Function called internally by drtmle to perform simultaneous fluctuation 
-#' of the initial estimator of Q (i.e., solves both EIF estimating eqn and 
+#' fluctuateQ
+#'
+#' Function called internally by drtmle to perform simultaneous fluctuation
+#' of the initial estimator of Q (i.e., solves both EIF estimating eqn and
 #' the new estimating eqn that results from misspecification of g)
-#' 
+#'
 #' @param Y The outcome
 #' @param A The treatment
 #' @param W The covariates
@@ -174,59 +191,70 @@ fluctuateQ2 <- function(Y, A, W, DeltaY, DeltaA,
 #' @param grn A list of reduced-dimension regression estimates evaluated on observed data
 #' @param coefTol A tolerance level on the magnitude of the coefficient that flags the
 #' result as potentially the result of numeric instability.
-#' @param reduction A character indicating what reduced dimension regression was used. 
-#' @param a_0 A list of fixed treatment values 
-#' 
+#' @param reduction A character indicating what reduced dimension regression was used.
+#' @param a_0 A list of fixed treatment values
+#'
 #' @importFrom SuperLearner trimLogit
 #' @importFrom stats predict glm
 #'
-fluctuateQ <- function(Y, A, W, DeltaY, DeltaA, 
-                       Qn, gn, grn, a_0, reduction, coefTol=1e5){
-  QnStar <- mapply(a = a_0, Q = Qn, g = gn, gr = grn, FUN=function(a, Q, g, gr){
-    l <- min(Y, na.rm = TRUE); u <- max(Y, na.rm = TRUE)
+fluctuateQ <- function(Y, A, W, DeltaY, DeltaA,
+                       Qn, gn, grn, a_0, reduction, coefTol=1e5) {
+  QnStar <- mapply(a = a_0, Q = Qn, g = gn, gr = grn, FUN = function(a, Q, g, gr) {
+    l <- min(Y, na.rm = TRUE)
+    u <- max(Y, na.rm = TRUE)
     Yscale <- (Y - l) / (u - l)
     off <- SuperLearner::trimLogit((Q - l) / (u - l))
 
-    H1 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1)/g
-    if(reduction=="univariate"){
-      H2 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1)/gr$grn2 * gr$grn1
-    }else if(reduction=="bivariate"){
-      H2 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1)/gr$grn2 * (gr$grn2-g)/g
+    H1 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1) / g
+    if (reduction == "univariate") {
+      H2 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1) / gr$grn2 * gr$grn1
+    } else if (reduction == "bivariate") {
+      H2 <- as.numeric(A == a & DeltaA == 1 & DeltaY == 1) / gr$grn2 * (gr$grn2 - g) / g
     }
 
     suppressWarnings(
-    fm <- stats::glm(Yscale ~ -1 + offset(off) + H1 + H2, start = c(0,0),
-               data = data.frame(Y = Y, off = off, H1 = H1, H2 = H2), 
-               family = "binomial")
+      fm <- stats::glm(
+        Yscale ~ -1 + offset(off) + H1 + H2, start = c(0, 0),
+        data = data.frame(Y = Y, off = off, H1 = H1, H2 = H2),
+        family = "binomial"
+      )
     )
-    if(!fm$converged | abs(max(fm$coef)) > coefTol){
+    if (!fm$converged | abs(max(fm$coef)) > coefTol) {
       # if it doesn't converge, try with no starting values
       suppressWarnings(
-      fm <- stats::glm(Yscale ~ -1 + offset(off) + H1 + H2, 
-                data = data.frame(Y = Y, off = off, H1 = H1, H2 = H2), 
-                family = "binomial")
+        fm <- stats::glm(
+          Yscale ~ -1 + offset(off) + H1 + H2,
+          data = data.frame(Y = Y, off = off, H1 = H1, H2 = H2),
+          family = "binomial"
+        )
       )
-      if(!fm$converged | abs(max(fm$coef)) > coefTol){
+      if (!fm$converged | abs(max(fm$coef)) > coefTol) {
         # warning("No sane fluctuation found. Proceeding using current estimates.")
-        if(reduction == "univariate"){
+        if (reduction == "univariate") {
           return(list(est = Q, eps = rep(0, 2)))
-        }else if(reduction == "bivariate"){
+        } else if (reduction == "bivariate") {
           return(list(est = Q, eps = rep(0, 2)))
         }
       }
     }
-    
-    if(reduction=="univariate"){
+
+    if (reduction == "univariate") {
       Qnstar <- stats::predict(
-        fm, type = "response", newdata = data.frame(off = off, H1 = 1/g, 
-          H2 = 1/gr$grn2 * gr$grn1))*(u-l) +l 
-        return(list(est = Qnstar, eps = fm$coef))
-      }else if(reduction == "bivariate"){
-        Qnstar <- stats::predict(
-          fm, type = "response", newdata = data.frame(off = off, H1 = 1/g, 
-            H2 = 1/gr$grn2 * (gr$grn2-g)/g))*(u-l) + l
-        return(list(est = Qnstar, eps = fm$coef))
-      }
-  }, SIMPLIFY=FALSE)
+        fm, type = "response", newdata = data.frame(
+          off = off, H1 = 1 / g,
+          H2 = 1 / gr$grn2 * gr$grn1
+        )
+      ) * (u - l) + l
+      return(list(est = Qnstar, eps = fm$coef))
+    } else if (reduction == "bivariate") {
+      Qnstar <- stats::predict(
+        fm, type = "response", newdata = data.frame(
+          off = off, H1 = 1 / g,
+          H2 = 1 / gr$grn2 * (gr$grn2 - g) / g
+        )
+      ) * (u - l) + l
+      return(list(est = Qnstar, eps = fm$coef))
+    }
+  }, SIMPLIFY = FALSE)
   QnStar
 }

--- a/R/inf_functions.R
+++ b/R/inf_functions.R
@@ -1,52 +1,55 @@
 #' Evaluate usual efficient influence function
-#' 
+#'
 #' @param A A vector of binary treatment assignment (assumed to be equal to 0 or 1)
-#' @param Y A numeric of continuous or binary outcomes. 
+#' @param Y A numeric of continuous or binary outcomes.
 #' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if missing 1 if observed)
 #' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if missing 1 if observed)
 #' @param Qn List of estimated outcome regression evaluated at observations
 #' @param gn List of estimated propensity scores evaluated at observations
 #' @param psi_n List of estimated ATEs
 #' @param a_0 Vector of values to return marginal mean
-#' 
+#'
 
-eval_Dstar <- function(A, Y, DeltaY, DeltaA, Qn, gn, psi_n, a_0){
-	return(mapply(a=split(a_0,1:length(a_0)),Q=Qn,g=gn,p=psi_n,FUN=function(a,Q,g,p){
-		# in order for influence function computations to compute properly
-  		# replace missing A and Y by arbitrary numerics.
-  		# Note that when these are missing, they are always getting multiplied
-  		# by 0, but R return 0*NA = NA for some reason and this is a hacky fix
-  		# to get around that. 
-    	modA <- A; modA[is.na(A)] <- -999
-    	modY <- Y; modY[is.na(Y)] <- -999
-    	as.numeric(modA == a & DeltaA == 1 & DeltaY == 1)/g * (modY - Q) + Q - p
-  	},SIMPLIFY=FALSE))
+eval_Dstar <- function(A, Y, DeltaY, DeltaA, Qn, gn, psi_n, a_0) {
+  return(mapply(a = split(a_0, 1:length(a_0)), Q = Qn, g = gn, p = psi_n, FUN = function(a, Q, g, p) {
+    # in order for influence function computations to compute properly
+    # replace missing A and Y by arbitrary numerics.
+    # Note that when these are missing, they are always getting multiplied
+    # by 0, but R return 0*NA = NA for some reason and this is a hacky fix
+    # to get around that.
+    modA <- A
+    modA[is.na(A)] <- -999
+    modY <- Y
+    modY[is.na(Y)] <- -999
+    as.numeric(modA == a & DeltaA == 1 & DeltaY == 1) / g * (modY - Q) + Q - p
+  }, SIMPLIFY = FALSE))
 }
 
 #' Evaluate extra piece of efficient influence function resulting from
 #' misspecification of outcome regression
-#' 
+#'
 #' @param A A vector of binary treatment assignment (assumed to be equal to 0 or 1)
 #' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if missing 1 if observed)
 #' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if missing 1 if observed)
 #' @param Qrn List of estimated reduced-dimension outcome regression evaluated at observations
 #' @param gn List of estimated propensity scores evaluated at observations
 #' @param a_0 Vector of values to return marginal mean
-#' 
+#'
 
-eval_Dstar_g <- function(A, DeltaY, DeltaA, Qrn, gn, a_0){
-	return(mapply(a=split(a_0,1:length(a_0)),Qr=Qrn,g=gn,FUN=function(a,Qr,g){
-      modA <- A; modA[is.na(A)] <- -999
-      Qr/g * (as.numeric(modA == a & DeltaA == 1 & DeltaY == 1) - g)
-    },SIMPLIFY=FALSE))
+eval_Dstar_g <- function(A, DeltaY, DeltaA, Qrn, gn, a_0) {
+  return(mapply(a = split(a_0, 1:length(a_0)), Qr = Qrn, g = gn, FUN = function(a, Qr, g) {
+    modA <- A
+    modA[is.na(A)] <- -999
+    Qr / g * (as.numeric(modA == a & DeltaA == 1 & DeltaY == 1) - g)
+  }, SIMPLIFY = FALSE))
 }
 
 
 #' Evaluate extra piece of efficient influence function resulting from
 #' misspecification of propensity score
-#' 
+#'
 #' @param A A vector of binary treatment assignment (assumed to be equal to 0 or 1)
-#' @param Y A numeric of continuous or binary outcomes. 
+#' @param Y A numeric of continuous or binary outcomes.
 #' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if missing 1 if observed)
 #' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if missing 1 if observed)
 #' @param Qn List of estimated outcome regression evaluated at observations
@@ -55,54 +58,61 @@ eval_Dstar_g <- function(A, DeltaY, DeltaA, Qrn, gn, a_0){
 #' @param a_0 Vector of values to return marginal mean
 #' @param reduction A character equal to \code{"univariate"} for a univariate misspecification correction or \code{"bivariate"}
 #' for the bivariate version.
-#' 
-eval_Dstar_Q <- function(A, Y, DeltaY, DeltaA, Qn, gn, grn, a_0, reduction){
-	if(reduction=="univariate"){
-      return(mapply(a=split(a_0,1:length(a_0)),Q=Qn,gr=grn,FUN=function(a,Q,gr){
-        modA <- A; modA[is.na(A)] <- -999
-        modY <- Y; modY[is.na(Y)] <- -999
-        as.numeric(modA == a & DeltaA == 1 & DeltaY == 1)/gr$grn2 * gr$grn1 * (modY-Q)
-      },SIMPLIFY=FALSE))
-    }else if(reduction=="bivariate"){
-      return(mapply(a=split(a_0,1:length(a_0)),Q=Qn,g=gn, gr=grn,FUN=function(a,Q,gr,g){
-        modA <- A; modA[is.na(A)] <- -999
-        modY <- Y; modY[is.na(Y)] <- -999
-        as.numeric(modA==a & DeltaA == 1 & DeltaY == 1)/gr$grn2 * (gr$grn2 - g)/g * (modY-Q)
-      },SIMPLIFY=FALSE))
-    }
+#'
+eval_Dstar_Q <- function(A, Y, DeltaY, DeltaA, Qn, gn, grn, a_0, reduction) {
+  if (reduction == "univariate") {
+    return(mapply(a = split(a_0, 1:length(a_0)), Q = Qn, gr = grn, FUN = function(a, Q, gr) {
+      modA <- A
+      modA[is.na(A)] <- -999
+      modY <- Y
+      modY[is.na(Y)] <- -999
+      as.numeric(modA == a & DeltaA == 1 & DeltaY == 1) / gr$grn2 * gr$grn1 * (modY - Q)
+    }, SIMPLIFY = FALSE))
+  } else if (reduction == "bivariate") {
+    return(mapply(a = split(a_0, 1:length(a_0)), Q = Qn, g = gn, gr = grn, FUN = function(a, Q, gr, g) {
+      modA <- A
+      modA[is.na(A)] <- -999
+      modY <- Y
+      modY[is.na(Y)] <- -999
+      as.numeric(modA == a & DeltaA == 1 & DeltaY == 1) / gr$grn2 * (gr$grn2 - g) / g * (modY - Q)
+    }, SIMPLIFY = FALSE))
+  }
 }
 
 #' Evaluate usual influence function of IPTW
-#' 
+#'
 #' @param A A vector of binary treatment assignment (assumed to be equal to 0 or 1)
-#' @param Y A numeric of continuous or binary outcomes. 
+#' @param Y A numeric of continuous or binary outcomes.
 #' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if missing 1 if observed)
 #' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if missing 1 if observed)
 #' @param gn List of estimated propensity scores evaluated at observations
 #' @param a_0 Vector of values to return marginal mean
 #' @param psi_n List of estimated ATEs
 
-eval_Diptw <- function(A, Y, DeltaA, DeltaY, gn, psi_n, a_0){
-	return(mapply(a=split(a_0,1:length(a_0)),g=gn,psi=psi_n,FUN=function(a,g,psi){
-    	modA <- A; modA[is.na(A)] <- -999
-    	modY <- Y; modY[is.na(Y)] <- -999
-  		as.numeric(modA == a & DeltaA == 1 & DeltaY == 1)/g * modY - psi
-	},SIMPLIFY=FALSE))
+eval_Diptw <- function(A, Y, DeltaA, DeltaY, gn, psi_n, a_0) {
+  return(mapply(a = split(a_0, 1:length(a_0)), g = gn, psi = psi_n, FUN = function(a, g, psi) {
+    modA <- A
+    modA[is.na(A)] <- -999
+    modY <- Y
+    modY[is.na(Y)] <- -999
+    as.numeric(modA == a & DeltaA == 1 & DeltaY == 1) / g * modY - psi
+  }, SIMPLIFY = FALSE))
 }
 
 
 #' Evaluate extra piece of the influence function for the IPTW
-#' 
+#'
 #' @param A A vector of binary treatment assignment (assumed to be equal to 0 or 1)
 #' @param DeltaY Indicator of missing outcome (assumed to be equal to 0 if missing 1 if observed)
 #' @param DeltaA Indicator of missing treatment (assumed to be equal to 0 if missing 1 if observed)
 #' @param Qrn List of estimated reduced-dimension outcome regression evaluated at observations
 #' @param gn List of estimated propensity scores evaluated at observations
 #' @param a_0 Vector of values to return marginal mean
-#' 
-eval_Diptw_g <- function(A, DeltaA, DeltaY, Qrn, gn, a_0){
-	return(mapply(a=split(a_0,1:length(a_0)),Qr=Qrn,g=gn,FUN=function(a,Qr,g){
-	    modA <- A; modA[is.na(A)] <- -999
-	    Qr/g * (as.numeric(modA == a & DeltaA == 1 & DeltaY == 1) - g)
-  	},SIMPLIFY=FALSE))
+#'
+eval_Diptw_g <- function(A, DeltaA, DeltaY, Qrn, gn, a_0) {
+  return(mapply(a = split(a_0, 1:length(a_0)), Qr = Qrn, g = gn, FUN = function(a, Qr, g) {
+    modA <- A
+    modA[is.na(A)] <- -999
+    Qr / g * (as.numeric(modA == a & DeltaA == 1 & DeltaY == 1) - g)
+  }, SIMPLIFY = FALSE))
 }

--- a/R/method_fixes.R
+++ b/R/method_fixes.R
@@ -1,56 +1,60 @@
-#' Modification of convex combination least squares method 
+#' Modification of convex combination least squares method
 #' for \code{SuperLearner} that doesn't fail with duplicated predictors.
 #' Issue reported to \code{SuperLearner} maintainers. This function will
 #' be deprecated when a more robust fix in the \code{SuperLearner} package
 #' is implemented.
 #' @export
-method.CC_LS_mod <- function()
-{
-    computeCoef = function(Z, Y, libraryNames, verbose, obsWeights, 
-        ...) {
-        cvRisk <- apply(Z, 2, function(x) mean(obsWeights * (x - 
-            Y)^2))
-        names(cvRisk) <- libraryNames
-        compute <- function(x, y, wt = rep(1, length(y))) {
-            wX <- sqrt(wt) * x
-            wY <- sqrt(wt) * y
-            D <- crossprod(wX)
-            d <- crossprod(wX, wY)
-            A <- cbind(rep(1, ncol(wX)), diag(ncol(wX)))
-            bvec <- c(1, rep(0, ncol(wX)))
-            fit <- quadprog::solve.QP(Dmat = D, dvec = d, Amat = A, 
-                bvec = bvec, meq = 1)
-            invisible(fit)
-        }
-        colDup <- which(duplicated(round(Z, 8), MARGIN = 2))
-        modZ <- Z
-        if(length(colDup) > 0){
-        	warning(paste0("Algorithm ", colDup, " is duplicated. Setting weight to 0."))
-        	modZ <- modZ[,-colDup]
-        }
-        fit <- compute(x = modZ, y = Y, wt = obsWeights)
-        coef <- fit$solution
-        if(length(colDup) > 0){
-	        ind <- c(seq_along(coef),colDup-0.5)
-			coef <- c(coef,rep(0,length(colDup)))
-	        coef <- coef[order(ind)]
-		}
-        if (any(is.na(coef))) {
-            warning("Some algorithms have weights of NA, setting to 0.")
-            coef[is.na(coef)] = 0
-        }
-        coef[coef < 1e-04] <- 0
-        coef <- coef/sum(coef)
-        if (!sum(coef) > 0) 
-            warning("All algorithms have zero weight", call. = FALSE)
-        list(cvRisk = cvRisk, coef = coef, optimizer = fit)
+method.CC_LS_mod <- function() {
+  computeCoef <- function(Z, Y, libraryNames, verbose, obsWeights,
+                          ...) {
+    cvRisk <- apply(Z, 2, function(x) mean(obsWeights * (x -
+        Y) ^ 2))
+    names(cvRisk) <- libraryNames
+    compute <- function(x, y, wt = rep(1, length(y))) {
+      wX <- sqrt(wt) * x
+      wY <- sqrt(wt) * y
+      D <- crossprod(wX)
+      d <- crossprod(wX, wY)
+      A <- cbind(rep(1, ncol(wX)), diag(ncol(wX)))
+      bvec <- c(1, rep(0, ncol(wX)))
+      fit <- quadprog::solve.QP(
+        Dmat = D, dvec = d, Amat = A,
+        bvec = bvec, meq = 1
+      )
+      invisible(fit)
     }
-    computePred = function(predY, coef, ...) {
-        predY %*% matrix(coef)
+    colDup <- which(duplicated(round(Z, 8), MARGIN = 2))
+    modZ <- Z
+    if (length(colDup) > 0) {
+      warning(paste0("Algorithm ", colDup, " is duplicated. Setting weight to 0."))
+      modZ <- modZ[, -colDup]
     }
-    out <- list(require = "quadprog", computeCoef = computeCoef, 
-        computePred = computePred)
-    invisible(out)
+    fit <- compute(x = modZ, y = Y, wt = obsWeights)
+    coef <- fit$solution
+    if (length(colDup) > 0) {
+      ind <- c(seq_along(coef), colDup - 0.5)
+      coef <- c(coef, rep(0, length(colDup)))
+      coef <- coef[order(ind)]
+    }
+    if (any(is.na(coef))) {
+      warning("Some algorithms have weights of NA, setting to 0.")
+      coef[is.na(coef)] <- 0
+    }
+    coef[coef < 1e-04] <- 0
+    coef <- coef / sum(coef)
+    if (!sum(coef) > 0) {
+      warning("All algorithms have zero weight", call. = FALSE)
+    }
+    list(cvRisk = cvRisk, coef = coef, optimizer = fit)
+  }
+  computePred <- function(predY, coef, ...) {
+    predY %*% matrix(coef)
+  }
+  out <- list(
+    require = "quadprog", computeCoef = computeCoef,
+    computePred = computePred
+  )
+  invisible(out)
 }
 
 #' Modification of convex combination negative log likelihood method
@@ -61,73 +65,81 @@ method.CC_LS_mod <- function()
 #' @importFrom SuperLearner trimLogit
 #' @importFrom stats plogis
 #' @export
-method.CC_nloglik_mod <- function () 
-{
-    computePred = function(predY, coef, control, ...) {
-        if (sum(coef != 0) == 0) {
-            stop("All metalearner coefficients are zero, cannot compute prediction.")
-        }
-        stats::plogis(SuperLearner::trimLogit(predY[, coef != 0], trim = control$trimLogit) %*% 
-            matrix(coef[coef != 0]))
+method.CC_nloglik_mod <- function() {
+  computePred <- function(predY, coef, control, ...) {
+    if (sum(coef != 0) == 0) {
+      stop("All metalearner coefficients are zero, cannot compute prediction.")
     }
-    computeCoef = function(Z, Y, libraryNames, obsWeights, control, 
-        verbose, ...) {
-        colDup <- which(duplicated(round(Z, 8), MARGIN = 2))
-        modZ <- Z
-        if(length(colDup) > 0){
-            warning(paste0("Algorithm ", colDup, " is duplicated. Setting weight to 0."))
-            modZ <- modZ[,-colDup]
+    stats::plogis(SuperLearner::trimLogit(predY[, coef != 0], trim = control$trimLogit) %*%
+      matrix(coef[coef != 0]))
+  }
+  computeCoef <- function(Z, Y, libraryNames, obsWeights, control,
+                          verbose, ...) {
+    colDup <- which(duplicated(round(Z, 8), MARGIN = 2))
+    modZ <- Z
+    if (length(colDup) > 0) {
+      warning(paste0("Algorithm ", colDup, " is duplicated. Setting weight to 0."))
+      modZ <- modZ[, -colDup]
+    }
+    modlogitZ <- SuperLearner::trimLogit(modZ, control$trimLogit)
+    logitZ <- SuperLearner::trimLogit(Z, control$trimLogit)
+    cvRisk <- apply(logitZ, 2, function(x) -sum(2 * obsWeights *
+        ifelse(Y, stats::plogis(x, log.p = TRUE), stats::plogis(
+          x, log.p = TRUE,
+          lower.tail = FALSE
+        ))))
+    names(cvRisk) <- libraryNames
+    obj_and_grad <- function(y, x, w = NULL) {
+      y <- y
+      x <- x
+      function(beta) {
+        xB <- x %*% cbind(beta)
+        loglik <- y * stats::plogis(xB, log.p = TRUE) + (1 -
+          y) * stats::plogis(xB, log.p = TRUE, lower.tail = FALSE)
+        if (!is.null(w)) {
+          loglik <- loglik * w
         }
-        modlogitZ = SuperLearner::trimLogit(modZ, control$trimLogit)
-        logitZ = SuperLearner::trimLogit(Z, control$trimLogit)
-        cvRisk <- apply(logitZ, 2, function(x) -sum(2 * obsWeights * 
-            ifelse(Y, stats::plogis(x, log.p = TRUE), stats::plogis(x, log.p = TRUE, 
-                lower.tail = FALSE))))
-        names(cvRisk) <- libraryNames
-        obj_and_grad <- function(y, x, w = NULL) {
-            y <- y
-            x <- x
-            function(beta) {
-                xB <- x %*% cbind(beta)
-                loglik <- y * stats::plogis(xB, log.p = TRUE) + (1 - 
-                  y) * stats::plogis(xB, log.p = TRUE, lower.tail = FALSE)
-                if (!is.null(w)) 
-                  loglik <- loglik * w
-                obj <- -2 * sum(loglik)
-                p <- stats::plogis(xB)
-                grad <- if (is.null(w)) 
-                  2 * crossprod(x, cbind(p - y))
-                else 2 * crossprod(x, w * cbind(p - y))
-                list(objective = obj, gradient = grad)
-            }
+        obj <- -2 * sum(loglik)
+        p <- stats::plogis(xB)
+        grad <- if (is.null(w)) {
+          2 * crossprod(x, cbind(p - y))
+        } else {
+          2 * crossprod(x, w * cbind(p - y))
         }
+        list(objective = obj, gradient = grad)
+      }
+    }
 
-        lower_bounds = rep(0, ncol(modZ))
-        upper_bounds = rep(1, ncol(modZ))
-        if (anyNA(cvRisk)) {
-            upper_bounds[is.na(cvRisk)] = 0
-        }
-        r <- nloptr::nloptr(x0 = rep(1/ncol(modZ), ncol(modZ)), eval_f = obj_and_grad(Y, 
-            modlogitZ), lb = lower_bounds, ub = upper_bounds, eval_g_eq = function(beta) (sum(beta) - 
-            1), eval_jac_g_eq = function(beta) rep(1, length(beta)), 
-            opts = list(algorithm = "NLOPT_LD_SLSQP", xtol_abs = 1e-08))
-        if (r$status < 1 || r$status > 4) {
-            warning(r$message)
-        }
-        coef <- r$solution
-        if(length(colDup) > 0){
-            ind <- c(seq_along(coef),colDup - 0.5)
-            coef <- c(coef,rep(0,length(colDup)))
-            coef <- coef[order(ind)]
-        }
-        if (anyNA(coef)) {
-            warning("Some algorithms have weights of NA, setting to 0.")
-            coef[is.na(coef)] <- 0
-        }
-        coef[coef < 1e-04] <- 0
-        coef <- coef/sum(coef)
-        out <- list(cvRisk = cvRisk, coef = coef, optimizer = r)
-        return(out)
+    lower_bounds <- rep(0, ncol(modZ))
+    upper_bounds <- rep(1, ncol(modZ))
+    if (anyNA(cvRisk)) {
+      upper_bounds[is.na(cvRisk)] <- 0
     }
-    list(require = "nloptr", computeCoef = computeCoef, computePred = computePred)
+    r <- nloptr::nloptr(
+      x0 = rep(1 / ncol(modZ), ncol(modZ)), eval_f = obj_and_grad(
+        Y,
+        modlogitZ
+      ), lb = lower_bounds, ub = upper_bounds, eval_g_eq = function(beta) (sum(beta) -
+          1), eval_jac_g_eq = function(beta) rep(1, length(beta)),
+      opts = list(algorithm = "NLOPT_LD_SLSQP", xtol_abs = 1e-08)
+    )
+    if (r$status < 1 || r$status > 4) {
+      warning(r$message)
+    }
+    coef <- r$solution
+    if (length(colDup) > 0) {
+      ind <- c(seq_along(coef), colDup - 0.5)
+      coef <- c(coef, rep(0, length(colDup)))
+      coef <- coef[order(ind)]
+    }
+    if (anyNA(coef)) {
+      warning("Some algorithms have weights of NA, setting to 0.")
+      coef[is.na(coef)] <- 0
+    }
+    coef[coef < 1e-04] <- 0
+    coef <- coef / sum(coef)
+    out <- list(cvRisk = cvRisk, coef = coef, optimizer = r)
+    return(out)
+  }
+  list(require = "nloptr", computeCoef = computeCoef, computePred = computePred)
 }

--- a/R/sl_npreg.R
+++ b/R/sl_npreg.R
@@ -1,23 +1,23 @@
 #' Super learner wrapper for kernel regression
-#' 
+#'
 #' Kernel regression based on the \href{https://CRAN.R-project.org/package=np}{np}
-#' package. Uses leave-one-out cross-validation to fit a kernel regression. 
+#' package. Uses leave-one-out cross-validation to fit a kernel regression.
 #' See \code{?npreg} for more details.
-#' 
+#'
 #' @param Y A vector of outcomes.
-#' @param X A matrix or data.frame of training data predictors. 
+#' @param X A matrix or data.frame of training data predictors.
 #' @param family Not used by the function directly, but ensures compatibility with \code{SuperLearner}.
 #' @param newX A test set of predictors.
 #' @param obsWeights Not used by the function directly, but ensures compatibility with \code{SuperLearner}.
 #' @param rangeThresh If the the range of the outcomes is smaller than this number, the method
-#' returns the empirical average of the outcomes. Used for computational expediency and stability.  
+#' returns the empirical average of the outcomes. Used for computational expediency and stability.
 #' @param ... Other arguments (not currently used).
-#' 
+#'
 #' @importFrom np npregbw npreg
 #' @importFrom stats predict as.formula
-#' 
-#' @export 
-#' 
+#'
+#' @export
+#'
 #' @examples
 #' # simulate data
 #' set.seed(1234)
@@ -27,25 +27,27 @@
 #' # fit npreg
 #' fit <- SL.npreg(Y = Y, X = X, newX = X)
 
-SL.npreg <- function (Y, X, newX, family = gaussian(), 
-                      obsWeights = rep(1, length(Y)), 
-                      rangeThresh=1e-7, ...) 
-{
+SL.npreg <- function(Y, X, newX, family = gaussian(),
+                     obsWeights = rep(1, length(Y)),
+                     rangeThresh=1e-7, ...) {
   # turn off annoying messages
   options(np.messages = FALSE)
   # check range threshold
-  if(abs(diff(range(Y))) <= rangeThresh){
+  if (abs(diff(range(Y))) <= rangeThresh) {
     thisMod <- glm(Y ~ 1, data = X)
-  }else{
+  } else {
     # bandwidth selection
-    bw <- np::npregbw(stats::as.formula(
-            paste("Y ~", paste(names(X), collapse = "+"))), data = X,
-          ftol=0.01, tol=0.01, remin=FALSE)
-  
+    bw <- np::npregbw(
+      stats::as.formula(
+        paste("Y ~", paste(names(X), collapse = "+"))
+      ), data = X,
+      ftol = 0.01, tol = 0.01, remin = FALSE
+    )
+
     # fit the kernel regression
     thisMod <- np::npreg(bw)
   }
-  
+
   pred <- stats::predict(thisMod, newdata = newX)
   fit <- list(object = thisMod)
   class(fit) <- "SL.npreg"
@@ -54,13 +56,13 @@ SL.npreg <- function (Y, X, newX, family = gaussian(),
 }
 
 #' Predict method for SL.npreg
-#' 
-#' Method for predicting SL.npreg objects. 
-#' 
+#'
+#' Method for predicting SL.npreg objects.
+#'
 #' @param object An object of class \code{"SL.npreg"}.
 #' @param newdata The new data used to obtain predictions.
 #' @param ... Other arguments passed to predict.
-#' 
+#'
 #' @importFrom stats predict
 #' @method predict SL.npreg
 #' @export
@@ -76,7 +78,7 @@ SL.npreg <- function (Y, X, newX, family = gaussian(),
 #' newX <- data.frame(X1 = c(-1,0,1))
 #' pred <- predict(fit$fit, newdata = newX)
 
-predict.SL.npreg <- function(object, newdata, ...){
+predict.SL.npreg <- function(object, newdata, ...) {
   pred <- stats::predict(object = object$object, newdata = newdata)
   pred
 }

--- a/R/test.R
+++ b/R/test.R
@@ -1,45 +1,45 @@
 #' Wald tests for drtmle and adaptive_iptw objects
 #' @param ... Arguments to be passed to method
 #' @export
-wald_test <- function(...){
-	UseMethod("wald_test")
+wald_test <- function(...) {
+  UseMethod("wald_test")
 }
 
 #' Wald tests for drtmle objects
-#' 
+#'
 #' @param object An object of class \code{"drtmle"}
-#' @param est A vector indicating for which estimators to return a 
+#' @param est A vector indicating for which estimators to return a
 #' confidence interval. Possible estimators include the TMLE with doubly robust
-#' inference (\code{"drtmle"}, recommended), the AIPTW with additional correction 
-#' for misspecification (\code{"aiptw_c"}, not recommended), the standard TMLE 
-#' (\code{"tmle"}, recommended only for comparison to "drtmle"), the standard 
-#' AIPTW (\code{"aiptw"}, recommended only for comparison to "drtmle"), and 
+#' inference (\code{"drtmle"}, recommended), the AIPTW with additional correction
+#' for misspecification (\code{"aiptw_c"}, not recommended), the standard TMLE
+#' (\code{"tmle"}, recommended only for comparison to "drtmle"), the standard
+#' AIPTW (\code{"aiptw"}, recommended only for comparison to "drtmle"), and
 #' G-computation (\code{"gcomp"}, not recommended).
-#' @param null The null hypothesis value. 
+#' @param null The null hypothesis value.
 #' @param contrast This option specifies what parameter to return confidence intervals for.
 #' If \code{contrast=NULL}, then test the null hypothesis that the covariate-adjusted
-#' marginal means equal the value(s) specified in \code{null}. 
+#' marginal means equal the value(s) specified in \code{null}.
 #' \code{contrast} can also be a numeric vector of ones, negative ones,
 #' and zeros to define linear combinations of the various means (e.g., to estimate an average
-#' treatment effect, see examples). In this case, we test the null hypothesis that the 
-#' linear combination of means equals the value specified in \code{null}. 
+#' treatment effect, see examples). In this case, we test the null hypothesis that the
+#' linear combination of means equals the value specified in \code{null}.
 #' \code{contrast} can also be a list with named functions
 #' \code{f}, \code{h}, and \code{fh_grad}. The function \code{f} takes
-#' as input argument \code{eff} and specifies which transformation 
-#' of the effect measure to test. The function \code{h} defines the contrast 
+#' as input argument \code{eff} and specifies which transformation
+#' of the effect measure to test. The function \code{h} defines the contrast
 #' to be estimated and should take as input \code{est}, a vector
 #' of the same length as \code{object$a_0}, and output the desired contrast. The function
 #' \code{fh_grad} is the gradient of the function \code{h(f())}. The function
-#' computes a test of the null hypothesis that \code{h(f(object$est)) = null}. 
-#' See examples. 
+#' computes a test of the null hypothesis that \code{h(f(object$est)) = null}.
+#' See examples.
 #' @param ... Other options (not currently used).
-#' 
+#'
 #' @importFrom stats pnorm
 #' @export
 #' @method wald_test drtmle
 #' @return An object of class \code{"ci.drtmle"} with point estimates and
-#' confidence intervals of the specified level. 
-#' 
+#' confidence intervals of the specified level.
+#'
 #' @examples
 #' # load super learner
 #' library(SuperLearner)
@@ -59,10 +59,10 @@ wald_test <- function(...){
 #'             SL_gr="SL.glm", maxIter = 1)
 #' # get hypothesis test that each mean = 0.5
 #' test_mean <- wald_test(fit1, null = 0.5)
-#' 
+#'
 #' # get test that ATE = 0
 #' test_ATE <- wald_test(fit1, null = 0, contrast = c(1,-1))
-#' 
+#'
 #' # get test that risk ratio = 1, computing test on log scale
 #' myContrast <- list(f = function(eff){ log(eff) },
 #'                    f_inv = function(eff){ exp(eff) },
@@ -71,134 +71,137 @@ wald_test <- function(...){
 #' test_RR <- wald_test(fit1, contrast = myContrast, null = 1)
 
 wald_test.drtmle <- function(object, est = c("drtmle"), null = 0,
-                             contrast = NULL, ...){
-	if(class(object) != "drtmle"){
-		stop("wald_test only works with drtmle objects")
-	}
-	out <- vector(mode = "list", length = length(est))
-	names(out) <- est
-	# if no contrast then return an CI for each 
-	# covariate-adjusted mean
-	if(is.null(contrast)){
-		# make sure null is input properly
-		if(length(null) == 1){
-			null <- rep(null, length(object$a_0))
-		}else if(length(null) > length(object$a_0)){
-			stop("length of null should be one or same length as object$a_0")
-		}
+                             contrast = NULL, ...) {
+  if (class(object) != "drtmle") {
+    stop("wald_test only works with drtmle objects")
+  }
+  out <- vector(mode = "list", length = length(est))
+  names(out) <- est
+  # if no contrast then return an CI for each
+  # covariate-adjusted mean
+  if (is.null(contrast)) {
+    # make sure null is input properly
+    if (length(null) == 1) {
+      null <- rep(null, length(object$a_0))
+    } else if (length(null) > length(object$a_0)) {
+      stop("length of null should be one or same length as object$a_0")
+    }
 
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = length(object$a_0), ncol = 2)
-			for(j in seq_along(object$a_0)){
-				zstat <- (object[[est[i]]]$est[j]-null[j])/sqrt(object[[est[i]]]$cov[j,j])
-				pval <- 2*stats::pnorm(-abs(zstat))
-				out[[i]][j,] <- c(zstat,pval)
-			}
-			row.names(out[[i]]) <- paste0(
-              "H0: E[Y(",object$a_0,")]=",null
-          	)
-			colnames(out[[i]]) <- c("zstat","pval")
-		}
-	}else if(is.numeric(contrast)){
-		# check that contrast came in correctly
-		if(length(contrast) != length(object$a_0)){
-			stop("length of contrast vector not equal to length of a_0")
-		}
-		if(!all(contrast %in% c(-1,1,0))){
-			stop("contrast should only be -1, 1, or 0")
-		}
-		if(length(null) > 1){
-			stop("null length should be 1 if contrast is a linear combination")
-		}
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = 1, ncol = 2)
-			g <- matrix(contrast, nrow = length(contrast))
-			p <- matrix(object[[est[i]]]$est, nrow = length(contrast))
-			v <- object[[est[i]]]$cov
-			thisC <- t(g)%*%p
-			thisSe <- sqrt(t(g)%*%v%*%g)
-			zstat <- (thisC - null) / thisSe
-			pval <- 2*stats::pnorm(-abs(zstat))
-			out[[i]][1,] <- c(zstat, pval)
-			# E[Y(a_0[1])] - E[Y(a_0[2])]
-			indMinus <- which(contrast == -1)
-			indPlus <- which(contrast == 1)
-			plusTerms <- minusTerms <- ""
-			if(length(indMinus) > 0){
-				minusTerms <- paste0("E[Y(",object$a_0[indMinus],")]")
-			}
-			if(length(indPlus) > 0){
-				plusTerms <- paste0("E[Y(",object$a_0[indPlus],")]")
-			}
-			thisName <- paste0("H0:",paste0(plusTerms,collapse = "+"),
-			                   ifelse(length(indMinus)>0,"-",""),
-			                   paste0(minusTerms,collapse="-"),"=",null)
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = length(object$a_0), ncol = 2)
+      for (j in seq_along(object$a_0)) {
+        zstat <- (object[[est[i]]]$est[j] - null[j]) / sqrt(object[[est[i]]]$cov[j, j])
+        pval <- 2 * stats::pnorm(-abs(zstat))
+        out[[i]][j, ] <- c(zstat, pval)
+      }
+      row.names(out[[i]]) <- paste0(
+        "H0: E[Y(", object$a_0, ")]=", null
+      )
+      colnames(out[[i]]) <- c("zstat", "pval")
+    }
+  } else if (is.numeric(contrast)) {
+    # check that contrast came in correctly
+    if (length(contrast) != length(object$a_0)) {
+      stop("length of contrast vector not equal to length of a_0")
+    }
+    if (!all(contrast %in% c(-1, 1, 0))) {
+      stop("contrast should only be -1, 1, or 0")
+    }
+    if (length(null) > 1) {
+      stop("null length should be 1 if contrast is a linear combination")
+    }
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = 1, ncol = 2)
+      g <- matrix(contrast, nrow = length(contrast))
+      p <- matrix(object[[est[i]]]$est, nrow = length(contrast))
+      v <- object[[est[i]]]$cov
+      thisC <- t(g) %*% p
+      thisSe <- sqrt(t(g) %*% v %*% g)
+      zstat <- (thisC - null) / thisSe
+      pval <- 2 * stats::pnorm(-abs(zstat))
+      out[[i]][1, ] <- c(zstat, pval)
+      # E[Y(a_0[1])] - E[Y(a_0[2])]
+      indMinus <- which(contrast == -1)
+      indPlus <- which(contrast == 1)
+      plusTerms <- minusTerms <- ""
+      if (length(indMinus) > 0) {
+        minusTerms <- paste0("E[Y(", object$a_0[indMinus], ")]")
+      }
+      if (length(indPlus) > 0) {
+        plusTerms <- paste0("E[Y(", object$a_0[indPlus], ")]")
+      }
+      thisName <- paste0(
+        "H0:", paste0(plusTerms, collapse = "+"),
+        ifelse(length(indMinus) > 0, "-", ""),
+        paste0(minusTerms, collapse = "-"), "=", null
+      )
 
-			row.names(out[[i]]) <- thisName
-			colnames(out[[i]]) <- c("zstat","pval")
-		}
-	}else if(is.list(contrast)){
-		if(!all(c("f","h","fh_grad") %in% names(contrast))){
-			stop("some function missing in contrast. see ?wald_test for help.")
-		}
-		if(length(null) > 1){
-			stop("null length should be 1 if contrast is user-specified functions")
-		}
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = 1, ncol = 2)
-			thisC <- do.call(contrast$h,args=list(est = object[[est[i]]]$est))
-			f_thisC <- do.call(contrast$f,args=list(eff = thisC))
+      row.names(out[[i]]) <- thisName
+      colnames(out[[i]]) <- c("zstat", "pval")
+    }
+  } else if (is.list(contrast)) {
+    if (!all(c("f", "h", "fh_grad") %in% names(contrast))) {
+      stop("some function missing in contrast. see ?wald_test for help.")
+    }
+    if (length(null) > 1) {
+      stop("null length should be 1 if contrast is user-specified functions")
+    }
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = 1, ncol = 2)
+      thisC <- do.call(contrast$h, args = list(est = object[[est[i]]]$est))
+      f_thisC <- do.call(contrast$f, args = list(eff = thisC))
 
-			grad <- matrix(do.call(contrast$fh_grad,
-			                       args=list(est = object[[est[i]]]$est)
-			               ),nrow = length(object$a_0))
-			v <- object[[est[i]]]$cov
-			thisSe <- sqrt(t(grad)%*%v%*%grad)
-			f_null <- do.call(contrast$f, args = list(eff = null))
-			zstat <- (f_thisC - f_null)/ thisSe
-			pval <- 2*stats::pnorm(-abs(zstat))
-			out[[i]][1,] <- c(zstat,pval)
-			row.names(out[[i]]) <- paste0("H0: user contrast = ",null)
-			colnames(out[[i]]) <- c("zstat","pval")
-		}
-	}
-	class(out) <- "wald_test.drtmle"
-	return(out)
+      grad <- matrix(do.call(
+        contrast$fh_grad,
+        args = list(est = object[[est[i]]]$est)
+      ), nrow = length(object$a_0))
+      v <- object[[est[i]]]$cov
+      thisSe <- sqrt(t(grad) %*% v %*% grad)
+      f_null <- do.call(contrast$f, args = list(eff = null))
+      zstat <- (f_thisC - f_null) / thisSe
+      pval <- 2 * stats::pnorm(-abs(zstat))
+      out[[i]][1, ] <- c(zstat, pval)
+      row.names(out[[i]]) <- paste0("H0: user contrast = ", null)
+      colnames(out[[i]]) <- c("zstat", "pval")
+    }
+  }
+  class(out) <- "wald_test.drtmle"
+  return(out)
 }
 
 #' Wald tests for adaptive_iptw objects
-#' 
+#'
 #' @param object An object of class \code{"adaptive_iptw"}
-#' @param est A vector indicating for which estimators to return a 
-#' confidence interval. Possible estimators include the TMLE IPTW 
-#' (\code{"iptw_tmle"}, recommended), the one-step IPTW 
-#' (\code{"iptw_os"}, not recommended), the standard IPTW 
+#' @param est A vector indicating for which estimators to return a
+#' confidence interval. Possible estimators include the TMLE IPTW
+#' (\code{"iptw_tmle"}, recommended), the one-step IPTW
+#' (\code{"iptw_os"}, not recommended), the standard IPTW
 #' (\code{"iptw"}, recommended only for comparison to the other two estimators).
-#' @param null The null hypothesis value(s). 
+#' @param null The null hypothesis value(s).
 #' @param contrast This option specifies what parameter to return confidence intervals for.
 #' If \code{contrast=NULL}, then test the null hypothesis that the covariate-adjusted
-#' marginal means equal the value(s) specified in \code{null}. 
+#' marginal means equal the value(s) specified in \code{null}.
 #' \code{contrast} can also be a numeric vector of ones, negative ones,
 #' and zeros to define linear combinations of the various means (e.g., to estimate an average
-#' treatment effect, see examples). In this case, we test the null hypothesis that the 
-#' linear combination of means equals the value specified in \code{null}. 
+#' treatment effect, see examples). In this case, we test the null hypothesis that the
+#' linear combination of means equals the value specified in \code{null}.
 #' \code{contrast} can also be a list with named functions
 #' \code{f}, \code{h}, and \code{fh_grad}. The function \code{f} takes
-#' as input argument \code{eff} and specifies which transformation 
-#' of the effect measure to test. The function \code{h} defines the contrast 
+#' as input argument \code{eff} and specifies which transformation
+#' of the effect measure to test. The function \code{h} defines the contrast
 #' to be estimated and should take as input \code{est}, a vector
 #' of the same length as \code{object$a_0}, and output the desired contrast. The function
 #' \code{fh_grad} is the gradient of the function \code{h(f())}. The function
-#' computes a test of the null hypothesis that \code{h(f(object$est)) = null}. 
-#' See examples. 
+#' computes a test of the null hypothesis that \code{h(f(object$est)) = null}.
+#' See examples.
 #' @param ... Other options (not currently used).
-#' 
+#'
 #' @importFrom stats pnorm
 #' @export
 #' @method wald_test adaptive_iptw
 #' @return An object of class \code{"ci.adaptive_iptw"} with point estimates and
-#' confidence intervals of the specified level. 
-#' 
+#' confidence intervals of the specified level.
+#'
 #' @examples
 #' # load super learner
 #' library(SuperLearner)
@@ -212,13 +215,13 @@ wald_test.drtmle <- function(object, est = c("drtmle"), null = 0,
 #' fit1 <- adaptive_iptw(W = W, A = A, Y = Y, a_0 = c(1,0),
 #'                SL_g=c("SL.glm","SL.mean","SL.step"),
 #'                SL_Qr="SL.glm")
-#' 
+#'
 #' # get test that each mean = 0.5
 #' test_mean <- wald_test(fit1, null = 0.5)
-#' 
-#' # get test that the ATE = 0 
+#'
+#' # get test that the ATE = 0
 #' ci_ATE <- ci(fit1, contrast = c(1,-1), null = 0)
-#' 
+#'
 #' # get test for risk ratio = 1 on log scale
 #' myContrast <- list(f = function(eff){ log(eff) },
 #'                    f_inv = function(eff){ exp(eff) }, # not necessary
@@ -227,99 +230,102 @@ wald_test.drtmle <- function(object, est = c("drtmle"), null = 0,
 #' ci_RR <- ci(fit1, contrast = myContrast, null = 1)
 
 wald_test.adaptive_iptw <- function(object, est = c("iptw_tmle"), null = 0,
-                             contrast = NULL, ...){
-	if(any(est=="iptw")){
-		stop("Theory does not support inference for naive IPTW with super learner.")
-	}
-	if(class(object) != "adaptive_iptw"){
-		stop("ci only works with adaptive_iptw objects")
-	}
-	out <- vector(mode = "list", length = length(est))
-	names(out) <- est
-	# if no contrast then return an CI for each 
-	# covariate-adjusted mean
-	if(is.null(contrast)){
-		# make sure null is input properly
-		if(length(null) == 1){
-			null <- rep(null, length(object$a_0))
-		}else if(length(null) > length(object$a_0)){
-			stop("length of null should be one or same length as object$a_0")
-		}
+                                    contrast = NULL, ...) {
+  if (any(est == "iptw")) {
+    stop("Theory does not support inference for naive IPTW with super learner.")
+  }
+  if (class(object) != "adaptive_iptw") {
+    stop("ci only works with adaptive_iptw objects")
+  }
+  out <- vector(mode = "list", length = length(est))
+  names(out) <- est
+  # if no contrast then return an CI for each
+  # covariate-adjusted mean
+  if (is.null(contrast)) {
+    # make sure null is input properly
+    if (length(null) == 1) {
+      null <- rep(null, length(object$a_0))
+    } else if (length(null) > length(object$a_0)) {
+      stop("length of null should be one or same length as object$a_0")
+    }
 
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = length(object$a_0), ncol = 2)
-			for(j in seq_along(object$a_0)){
-				zstat <- (object[[est[i]]]$est[j]-null[j])/sqrt(object[[est[i]]]$cov[j,j])
-				pval <- 2*stats::pnorm(-abs(zstat))
-				out[[i]][j,] <- c(zstat,pval)
-			}
-			row.names(out[[i]]) <- paste0(
-              "H0: E[Y(",object$a_0,")]=",null
-          	)
-			colnames(out[[i]]) <- c("zstat","pval")
-		}
-	}else if(is.numeric(contrast)){
-		# check that contrast came in correctly
-		if(length(contrast) != length(object$a_0)){
-			stop("length of contrast vector not equal to length of a_0")
-		}
-		if(!all(contrast %in% c(-1,1,0))){
-			stop("contrast should only be -1, 1, or 0")
-		}
-		if(length(null) > 1){
-			stop("null length should be 1 if contrast is a linear combination")
-		}
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = 1, ncol = 2)
-			g <- matrix(contrast, nrow = length(contrast))
-			p <- matrix(object[[est[i]]]$est, nrow = length(contrast))
-			v <- object[[est[i]]]$cov
-			thisC <- t(g)%*%p
-			thisSe <- sqrt(t(g)%*%v%*%g)
-			zstat <- (thisC - null) / thisSe
-			pval <- 2*stats::pnorm(-abs(zstat))
-			out[[i]][1,] <- c(zstat, pval)
-			# E[Y(a_0[1])] - E[Y(a_0[2])]
-			indMinus <- which(contrast == -1)
-			indPlus <- which(contrast == 1)
-			plusTerms <- minusTerms <- ""
-			if(length(indMinus) > 0){
-				minusTerms <- paste0("E[Y(",object$a_0[indMinus],")]")
-			}
-			if(length(indPlus) > 0){
-				plusTerms <- paste0("E[Y(",object$a_0[indPlus],")]")
-			}
-			thisName <- paste0("H0:",paste0(plusTerms,collapse = "+"),
-			                   ifelse(length(indMinus)>0,"-",""),
-			                   paste0(minusTerms,collapse="-"),"=",null)
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = length(object$a_0), ncol = 2)
+      for (j in seq_along(object$a_0)) {
+        zstat <- (object[[est[i]]]$est[j] - null[j]) / sqrt(object[[est[i]]]$cov[j, j])
+        pval <- 2 * stats::pnorm(-abs(zstat))
+        out[[i]][j, ] <- c(zstat, pval)
+      }
+      row.names(out[[i]]) <- paste0(
+        "H0: E[Y(", object$a_0, ")]=", null
+      )
+      colnames(out[[i]]) <- c("zstat", "pval")
+    }
+  } else if (is.numeric(contrast)) {
+    # check that contrast came in correctly
+    if (length(contrast) != length(object$a_0)) {
+      stop("length of contrast vector not equal to length of a_0")
+    }
+    if (!all(contrast %in% c(-1, 1, 0))) {
+      stop("contrast should only be -1, 1, or 0")
+    }
+    if (length(null) > 1) {
+      stop("null length should be 1 if contrast is a linear combination")
+    }
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = 1, ncol = 2)
+      g <- matrix(contrast, nrow = length(contrast))
+      p <- matrix(object[[est[i]]]$est, nrow = length(contrast))
+      v <- object[[est[i]]]$cov
+      thisC <- t(g) %*% p
+      thisSe <- sqrt(t(g) %*% v %*% g)
+      zstat <- (thisC - null) / thisSe
+      pval <- 2 * stats::pnorm(-abs(zstat))
+      out[[i]][1, ] <- c(zstat, pval)
+      # E[Y(a_0[1])] - E[Y(a_0[2])]
+      indMinus <- which(contrast == -1)
+      indPlus <- which(contrast == 1)
+      plusTerms <- minusTerms <- ""
+      if (length(indMinus) > 0) {
+        minusTerms <- paste0("E[Y(", object$a_0[indMinus], ")]")
+      }
+      if (length(indPlus) > 0) {
+        plusTerms <- paste0("E[Y(", object$a_0[indPlus], ")]")
+      }
+      thisName <- paste0(
+        "H0:", paste0(plusTerms, collapse = "+"),
+        ifelse(length(indMinus) > 0, "-", ""),
+        paste0(minusTerms, collapse = "-"), "=", null
+      )
 
-			row.names(out[[i]]) <- thisName
-			colnames(out[[i]]) <- c("zstat","pval")
-		}
-	}else if(is.list(contrast)){
-		if(!all(c("f","h","fh_grad") %in% names(contrast))){
-			stop("some function missing in contrast. see ?wald_test for help.")
-		}
-		if(length(null) > 1){
-			stop("null length should be 1 if contrast is user-specified functions")
-		}
-		for(i in seq_along(est)){
-			out[[i]] <- matrix(NA, nrow = 1, ncol = 2)
-			thisC <- do.call(contrast$h,args=list(est = object[[est[i]]]$est))
-			f_thisC <- do.call(contrast$f,args=list(eff = thisC))
+      row.names(out[[i]]) <- thisName
+      colnames(out[[i]]) <- c("zstat", "pval")
+    }
+  } else if (is.list(contrast)) {
+    if (!all(c("f", "h", "fh_grad") %in% names(contrast))) {
+      stop("some function missing in contrast. see ?wald_test for help.")
+    }
+    if (length(null) > 1) {
+      stop("null length should be 1 if contrast is user-specified functions")
+    }
+    for (i in seq_along(est)) {
+      out[[i]] <- matrix(NA, nrow = 1, ncol = 2)
+      thisC <- do.call(contrast$h, args = list(est = object[[est[i]]]$est))
+      f_thisC <- do.call(contrast$f, args = list(eff = thisC))
 
-			grad <- matrix(do.call(contrast$fh_grad,
-			                       args=list(est = object[[est[i]]]$est)
-			               ),nrow = length(object$a_0))
-			v <- object[[est[i]]]$cov
-			thisSe <- sqrt(t(grad)%*%v%*%grad)
-			zstat <- (f_thisC - null)/ thisSe
-			pval <- 2*stats::pnorm(-abs(zstat))
-			out[[i]][1,] <- c(zstat,pval)
-			row.names(out[[i]]) <- paste0("H0: user contrast = ",null)
-			colnames(out[[i]]) <- c("zstat","pval")
-		}
-	}
-	class(out) <- "wald_test.adaptive_iptw"
-	return(out)
+      grad <- matrix(do.call(
+        contrast$fh_grad,
+        args = list(est = object[[est[i]]]$est)
+      ), nrow = length(object$a_0))
+      v <- object[[est[i]]]$cov
+      thisSe <- sqrt(t(grad) %*% v %*% grad)
+      zstat <- (f_thisC - null) / thisSe
+      pval <- 2 * stats::pnorm(-abs(zstat))
+      out[[i]][1, ] <- c(zstat, pval)
+      row.names(out[[i]]) <- paste0("H0: user contrast = ", null)
+      colnames(out[[i]]) <- c("zstat", "pval")
+    }
+  }
+  class(out) <- "wald_test.adaptive_iptw"
+  return(out)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,44 +1,48 @@
-#--------------------------------------------------
+# --------------------------------------------------
 # Print methods
-#--------------------------------------------------
+# --------------------------------------------------
 #' Print the output of a \code{"drtmle"} object.
-#' 
+#'
 #' @param x A \code{"drtmle"} object
 #' @param ... Other arguments (not used)
 #' @export
 #' @method print drtmle
 
-print.drtmle <- function(x,...){
-  tmp <- list(est = cbind(x$drtmle$est),
-  	          cov = x$drtmle$cov)
+print.drtmle <- function(x, ...) {
+  tmp <- list(
+    est = cbind(x$drtmle$est),
+    cov = x$drtmle$cov
+  )
   row.names(tmp$est) <- x$a_0
   colnames(tmp$est) <- ""
   row.names(tmp$cov) <- colnames(tmp$cov) <- x$a_0
-  if(length(x$a_0) <= 4){
-  	print(tmp)
-  }else{
-  	tmp$cov <- diag(tmp$cov)
+  if (length(x$a_0) <= 4) {
+    print(tmp)
+  } else {
+    tmp$cov <- diag(tmp$cov)
   }
   invisible(tmp)
 }
 
 #' Print the output of a \code{"adaptive_iptw"} object.
-#' 
+#'
 #' @param x A \code{"adaptive_iptw"} object.
 #' @param ... Other arguments (not used)
 #' @export
 #' @method print adaptive_iptw
 
-print.adaptive_iptw <- function(x,...){
-  tmp <- list(est = cbind(x$iptw_tmle$est),
-  	          cov = x$iptw_tmle$cov)
+print.adaptive_iptw <- function(x, ...) {
+  tmp <- list(
+    est = cbind(x$iptw_tmle$est),
+    cov = x$iptw_tmle$cov
+  )
   row.names(tmp$est) <- x$a_0
   colnames(tmp$est) <- ""
   row.names(tmp$cov) <- colnames(tmp$cov) <- x$a_0
-  if(length(x$a_0) <= 4){
-  	print(tmp)
-  }else{
-  	tmp$cov <- diag(tmp$cov)
+  if (length(x$a_0) <= 4) {
+    print(tmp)
+  } else {
+    tmp$cov <- diag(tmp$cov)
   }
   invisible(tmp)
 }
@@ -47,37 +51,37 @@ print.adaptive_iptw <- function(x,...){
 #' Print the output of ci.drtmle
 #' @export
 #' @param x An object of class ci.drtmle
-#' @param digits Number of digits to round to 
+#' @param digits Number of digits to round to
 #' @param ... Other options (not currently used)
-#' @method print ci.drtmle	
+#' @method print ci.drtmle
 
-print.ci.drtmle <- function(x,digits = 3,...){
-	tmp <- lapply(x, round, digits = digits)
-	print(tmp)
+print.ci.drtmle <- function(x, digits = 3, ...) {
+  tmp <- lapply(x, round, digits = digits)
+  print(tmp)
   invisible(tmp)
 }
 
 #' Print the output of ci.adaptive_iptw
 #' @export
 #' @param x An object of class ci.adaptive_iptw
-#' @param digits Number of digits to round to 
+#' @param digits Number of digits to round to
 #' @param ... Other options (not currently used)
-#' @method print ci.adaptive_iptw 
+#' @method print ci.adaptive_iptw
 
-print.ci.adaptive_iptw <- function(x,digits = 3,...){
-	tmp <- lapply(x, round, digits = digits)
-	print(tmp)
+print.ci.adaptive_iptw <- function(x, digits = 3, ...) {
+  tmp <- lapply(x, round, digits = digits)
+  print(tmp)
   invisible(tmp)
 }
 
 #' Print the output of wald_test.drtmle
 #' @export
 #' @param x An object of class wald_test.drtmle
-#' @param digits Number of digits to round to 
+#' @param digits Number of digits to round to
 #' @param ... Other options (not currently used)
 #' @method print wald_test.drtmle
 
-print.wald_test.drtmle <- function(x,digits = 3,...){
+print.wald_test.drtmle <- function(x, digits = 3, ...) {
   tmp <- lapply(x, round, digits = digits)
   print(tmp)
   invisible(tmp)
@@ -86,22 +90,22 @@ print.wald_test.drtmle <- function(x,digits = 3,...){
 #' Print the output of wald_test.adaptive_iptw
 #' @export
 #' @param x An object of class wald_test.adaptive_iptw
-#' @param digits Number of digits to round to 
+#' @param digits Number of digits to round to
 #' @param ... Other options (not currently used)
-#' @method print wald_test.adaptive_iptw 
+#' @method print wald_test.adaptive_iptw
 
-print.wald_test.adaptive_iptw <- function(x,digits = 3,...){
+print.wald_test.adaptive_iptw <- function(x, digits = 3, ...) {
   tmp <- lapply(x, round, digits = digits)
   print(tmp)
   invisible(tmp)
 }
 
 
-#--------------------------------------------------
+# --------------------------------------------------
 # Plot methods
-#--------------------------------------------------
+# --------------------------------------------------
 #' Plot reduced dimension regression fits
-#' 
+#'
 #' @param x An object of class \code{"drtmle"}
 #' @param nPoints Number of points to plot lines (increase for less bumpy plot,
 #' decrease for faster evaluation).
@@ -125,17 +129,17 @@ print.wald_test.adaptive_iptw <- function(x,digits = 3,...){
 #'                stratify=FALSE,
 #'                SL_Q=c("SL.glm","SL.mean","SL.glm.interaction"),
 #'                SL_g=c("SL.glm","SL.mean","SL.glm.interaction"),
-#'                SL_Qr="SL.npreg", SL_gr="SL.npreg", 
+#'                SL_Qr="SL.npreg", SL_gr="SL.npreg",
 #'                maxIter = 1, returnModels = TRUE)
 #' # plot the reduced-dimension regression fits (not run)
 #' \dontrun{plot(fit1)}
 
-plot.drtmle <- function(x, nPoints = 500, 
-                        a_0 = x$a_0[1], ...){
+plot.drtmle <- function(x, nPoints = 500,
+                        a_0 = x$a_0[1], ...) {
   # ask to see next plot
   par(ask = TRUE)
   # check if returnModels is null
-  if(is.null(x$QrnMod) & is.null(x$grnMod)){
+  if (is.null(x$QrnMod) & is.null(x$grnMod)) {
     stop("Plot function only works if returnModels = TRUE.")
   }
 
@@ -146,113 +150,122 @@ plot.drtmle <- function(x, nPoints = 500,
   gn <- x$nuisance_drtmle$gnStar[[listInd]]
   Qn <- x$nuisance_drtmle$QnStar[[listInd]]
 
-  #------------------
+  # ------------------
   # plot Qrn fit
-  #------------------
+  # ------------------
   # number of fits (if no CV = 1, if CV > 1)
   nFit <- length(x$QrnMod)
-  # xlim = range of gn 
+  # xlim = range of gn
   xl <- range(gn)
   # prediction points
-  predP <- seq(xl[1],xl[2], length = nPoints)
+  predP <- seq(xl[1], xl[2], length = nPoints)
   # get predictions back for each Qrn fit
-  fit_Qrn <- lapply(x$QrnMod, function(y){
+  fit_Qrn <- lapply(x$QrnMod, function(y) {
     newDat <- data.frame(gn = predP)
-    if("glm" %in% class(y[[listInd]])){
+    if ("glm" %in% class(y[[listInd]])) {
       predict(y[[listInd]], newdata = newDat, type = "response")
-    }else if(class(y[[listInd]]) == "SuperLearner"){
+    } else if (class(y[[listInd]]) == "SuperLearner") {
       pred <- predict(y[[listInd]], newdata = newDat)
       # get sl prediction if meta learning did not fail
-      if(!all(y[[listInd]]$coef == 0)){
+      if (!all(y[[listInd]]$coef == 0)) {
         pred$pred
-      # otherwise get discrete super learner 
-      }else{
-        pred$library.predict[,which.min(y$cvRisk)]
+        # otherwise get discrete super learner
+      } else {
+        pred$library.predict[, which.min(y$cvRisk)]
       }
-    }else{
+    } else {
       predict(y[[listInd]]$fit, newdata = newDat, type = "response")
     }
   })
   # get ylimits
   yl <- range(unlist(fit_Qrn))
   # set up empty plot
-  plot(0, type = "n", xlim = xl, ylim = yl,
-       xaxt = "n", yaxt = "n", bty = "n", 
-       xlab = expression(g[n](W)), 
-       ylab = expression("E[Y-"*Q[n](W)*" | "*g[n](W)*"]"))
+  plot(
+    0, type = "n", xlim = xl, ylim = yl,
+    xaxt = "n", yaxt = "n", bty = "n",
+    xlab = expression(g[n](W)),
+    ylab = expression("E[Y-" * Q[n](W) * " | " * g[n](W) * "]")
+  )
   # add axes
-  axis(side = 1); axis(side = 2)
+  axis(side = 1)
+  axis(side = 2)
   # add lines
   invisible(lapply(fit_Qrn, lines, x = predP, lwd = 2, col = "gray50"))
 
-  #------------------
+  # ------------------
   # plot grn fit
-  #------------------
+  # ------------------
   # only plot if univariate reduction
   reduction <- as.list(x$call)$reduction
-  if(is.null(reduction)) reduction <- "univariate"
-  if(reduction == "univariate"){
-    # xlim = range of gn 
+  if (is.null(reduction)) reduction <- "univariate"
+  if (reduction == "univariate") {
+    # xlim = range of gn
     xl <- range(Qn)
     # prediction points
     predP <- seq(xl[1], xl[2], length = nPoints)
     ## get fitted values of g_{n,r,1}
-    fit_grn1 <- lapply(x$grnMod, function(y){
+    fit_grn1 <- lapply(x$grnMod, function(y) {
       newDat <- data.frame(Qn = predP)
-      if("glm" %in% class(y[[listInd]]$fm1)){
+      if ("glm" %in% class(y[[listInd]]$fm1)) {
         predict(y[[listInd]]$fm1, newdata = newDat, type = "response")
-      }else if(class(y[[listInd]]$fm1) == "SuperLearner"){
+      } else if (class(y[[listInd]]$fm1) == "SuperLearner") {
         pred <- predict(y[[listInd]]$fm1, newdata = newDat)
         # get sl prediction if meta learning did not fail
-        if(!all(y[[listInd]]$fm1$coef == 0)){
+        if (!all(y[[listInd]]$fm1$coef == 0)) {
           pred$pred
-        # otherwise get discrete super learner 
-        }else{
-          pred$library.predict[,which.min(y$cvRisk)]
+          # otherwise get discrete super learner
+        } else {
+          pred$library.predict[, which.min(y$cvRisk)]
         }
-      }else{
+      } else {
         predict(y[[listInd]]$fm1$fit, newdata = newDat, type = "response")
       }
     })
     # get ylimits
     yl <- range(unlist(fit_grn1))
     # set up empty plot
-    plot(0, type = "n", xlim = xl, ylim = yl,
-         xaxt = "n", yaxt = "n", bty = "n", 
-         xlab = expression(Q[n](W)), 
-         ylab = expression("E[{"*A-g[n](W)*"} / "*g[n](W)*"} | "*Q[n](W)*"]"))
+    plot(
+      0, type = "n", xlim = xl, ylim = yl,
+      xaxt = "n", yaxt = "n", bty = "n",
+      xlab = expression(Q[n](W)),
+      ylab = expression("E[{" * A - g[n](W) * "} / " * g[n](W) * "} | " * Q[n](W) * "]")
+    )
     # add axes
-    axis(side = 1); axis(side = 2)
+    axis(side = 1)
+    axis(side = 2)
     # add lines
     invisible(lapply(fit_grn1, lines, x = predP, lwd = 2, col = "gray50"))
 
     ## get fitted values of g_{n,r,2}
-    fit_grn2 <- lapply(x$grnMod, function(y){
+    fit_grn2 <- lapply(x$grnMod, function(y) {
       newDat <- data.frame(Qn = predP)
-      if("glm" %in% class(y[[listInd]]$fm2)){
+      if ("glm" %in% class(y[[listInd]]$fm2)) {
         predict(y[[listInd]]$fm2, newdata = newDat, type = "response")
-      }else if(class(y[[listInd]]$fm2) == "SuperLearner"){
+      } else if (class(y[[listInd]]$fm2) == "SuperLearner") {
         pred <- predict(y[[listInd]]$fm2, newdata = newDat)
         # get sl prediction if meta learning did not fail
-        if(!all(y[[listInd]]$fm2$coef == 0)){
+        if (!all(y[[listInd]]$fm2$coef == 0)) {
           pred$pred
-        # otherwise get discrete super learner 
-        }else{
-          pred$library.predict[,which.min(y$cvRisk)]
+          # otherwise get discrete super learner
+        } else {
+          pred$library.predict[, which.min(y$cvRisk)]
         }
-      }else{
+      } else {
         predict(y[[listInd]]$fm2$fit, newdata = newDat, type = "response")
       }
     })
     # get ylimits
     yl <- range(unlist(fit_grn2))
     # set up empty plot
-    plot(0, type = "n", xlim = xl, ylim = yl,
-         xaxt = "n", yaxt = "n", bty = "n", 
-         xlab = expression(Q[n](W)), 
-         ylab = expression("E[A | "*Q[n](W)*"]"))
+    plot(
+      0, type = "n", xlim = xl, ylim = yl,
+      xaxt = "n", yaxt = "n", bty = "n",
+      xlab = expression(Q[n](W)),
+      ylab = expression("E[A | " * Q[n](W) * "]")
+    )
     # add axes
-    axis(side = 1); axis(side = 2)
+    axis(side = 1)
+    axis(side = 2)
     # add lines
     invisible(lapply(fit_grn2, lines, x = predP, lwd = 2, col = "gray50"))
   }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,5 +1,7 @@
 .onAttach <- function(...) {
   packageStartupMessage("drtmle: TMLE with doubly robust inference")
-  packageStartupMessage("Version: ",
-                        utils::packageDescription("drtmle")$Version)
+  packageStartupMessage(
+    "Version: ",
+    utils::packageDescription("drtmle")$Version
+  )
 }

--- a/man/SL.npreg.Rd
+++ b/man/SL.npreg.Rd
@@ -25,7 +25,7 @@ returns the empirical average of the outcomes. Used for computational expediency
 }
 \description{
 Kernel regression based on the \href{https://CRAN.R-project.org/package=np}{np}
-package. Uses leave-one-out cross-validation to fit a kernel regression. 
+package. Uses leave-one-out cross-validation to fit a kernel regression.
 See \code{?npreg} for more details.
 }
 \examples{

--- a/man/adaptive_iptw.Rd
+++ b/man/adaptive_iptw.Rd
@@ -63,7 +63,7 @@ propensity score and reduced-dimension regressions.}
 
 \item{verbose}{A boolean indicating whether to print status updates.}
 
-\item{maxIter}{A numeric that sets the maximum number of iterations the TMLE 
+\item{maxIter}{A numeric that sets the maximum number of iterations the TMLE
 can perform in its fluctuation step.}
 
 \item{tolIC}{A numeric that defines the stopping criteria based on the
@@ -101,11 +101,11 @@ An object of class \code{"adaptive_iptw"}.
        observed data values.}
  \item{\code{iptw}}{A \code{list} of point estimates for the standard IPTW
        estimator. No estimate of the covariance matrix is provided because
-       theory does not support asymptotic Normality of the IPTW estimator if 
+       theory does not support asymptotic Normality of the IPTW estimator if
        super learning is used to estimate the propensity score.}
  \item{\code{gnMod}}{The fitted object for the propensity score. Returns
        \code{NULL} if \code{returnModels = FALSE}.}
- \item{\code{QrnMod}}{The fitted object for the reduced-dimension regression 
+ \item{\code{QrnMod}}{The fitted object for the reduced-dimension regression
        that guards against misspecification of the outcome regression.
        Returns \code{NULL} if \code{returnModels = FALSE}.}
  \item{\code{a_0}}{The treatment levels that were requested for computation

--- a/man/ci.adaptive_iptw.Rd
+++ b/man/ci.adaptive_iptw.Rd
@@ -10,10 +10,10 @@
 \arguments{
 \item{object}{An object of class \code{"adaptive_iptw"}}
 
-\item{est}{A vector indicating for which estimators to return a 
-confidence interval. Possible estimators include the TMLE IPTW 
-(\code{"iptw_tmle"}, recommended), the one-step IPTW 
-(\code{"iptw_os"}, not recommended), the standard IPTW 
+\item{est}{A vector indicating for which estimators to return a
+confidence interval. Possible estimators include the TMLE IPTW
+(\code{"iptw_tmle"}, recommended), the one-step IPTW
+(\code{"iptw_os"}, not recommended), the standard IPTW
 (\code{"iptw"}, recommended only for comparison to the other two estimators).}
 
 \item{level}{The nominal coverage probability of the desired confidence interval (should be
@@ -25,7 +25,7 @@ marginal means are computed. If instead, \code{contrast} is a numeric vector of 
 and zeros to define linear combinations of the various means (e.g., to estimate an average
 treatment effect, see example). Finally, \code{contrast} can be a list with named functions
 \code{f}, \code{f_inv}, \code{h}, and \code{fh_grad}. The first two functions should take
-as input argument \code{eff}. Respectively, these specify which transformation 
+as input argument \code{eff}. Respectively, these specify which transformation
 of the effect measure to compute the confidence interval for and the inverse
 transformation to put the confidence interval back on the original scale. The function \code{h}
 defines the contrast to be estimated and should take as input \code{est}, a vector
@@ -61,7 +61,7 @@ ci_mean <- ci(fit1)
 # get confidence intervals for ATE
 ci_ATE <- ci(fit1, contrast = c(1,-1))
 
-# get confidence intervals for risk ratio 
+# get confidence intervals for risk ratio
 # by inputting own contrast function
 # this computes CI on log scale and back transforms
 myContrast <- list(f = function(eff){ log(eff) },

--- a/man/ci.drtmle.Rd
+++ b/man/ci.drtmle.Rd
@@ -10,12 +10,12 @@
 \arguments{
 \item{object}{An object of class \code{"drtmle"}}
 
-\item{est}{A vector indicating for which estimators to return a 
+\item{est}{A vector indicating for which estimators to return a
 confidence interval. Possible estimators include the TMLE with doubly robust
-inference (\code{"drtmle"}, recommended), the AIPTW with additional correction 
-for misspecification (\code{"aiptw_c"}, not recommended), the standard TMLE 
-(\code{"tmle"}, recommended only for comparison to "drtmle"), the standard 
-AIPTW (\code{"aiptw"}, recommended only for comparison to "drtmle"), and 
+inference (\code{"drtmle"}, recommended), the AIPTW with additional correction
+for misspecification (\code{"aiptw_c"}, not recommended), the standard TMLE
+(\code{"tmle"}, recommended only for comparison to "drtmle"), the standard
+AIPTW (\code{"aiptw"}, recommended only for comparison to "drtmle"), and
 G-computation (\code{"gcomp"}, not recommended).}
 
 \item{level}{The nominal coverage probability of the desired confidence interval (should be
@@ -27,7 +27,7 @@ marginal means are computed. If instead, \code{contrast} is a numeric vector of 
 and zeros to define linear combinations of the various means (e.g., to estimate an average
 treatment effect, see example). Finally, \code{contrast} can be a list with named functions
 \code{f}, \code{f_inv}, \code{h}, and \code{fh_grad}. The first two functions should take
-as input argument \code{eff}. Respectively, these specify which transformation 
+as input argument \code{eff}. Respectively, these specify which transformation
 of the effect measure to compute the confidence interval for and the inverse
 transformation to put the confidence interval back on the original scale. The function \code{h}
 defines the contrast to be estimated and should take as input \code{est}, a vector

--- a/man/drtmle.Rd
+++ b/man/drtmle.Rd
@@ -21,14 +21,14 @@ drtmle(Y, A, W, DeltaA = as.numeric(!is.na(A)),
 
 \item{W}{A \code{data.frame} of named covariates.}
 
-\item{DeltaA}{A \code{numeric} vector of missing treatment indicator (assumed to be equal to
-0 if missing 1 if observed).}
+\item{DeltaA}{A \code{numeric} vector of missing treatment indicator (assumed
+to be equal to 0 if missing 1 if observed).}
 
-\item{DeltaY}{A \code{numeric} vector of missing outcome indicator (assumed to be equal to 0
-if missing 1 if observed).}
+\item{DeltaY}{A \code{numeric} vector of missing outcome indicator (assumed
+to be equal to 0 if missing 1 if observed).}
 
-\item{a_0}{A \code{numeric} vector of fixed treatment values at which to return marginal
-mean estimates.}
+\item{a_0}{A \code{numeric} vector of fixed treatment values at which to
+return marginal mean estimates.}
 
 \item{family}{A \code{family} object equal to either \code{binomial()} or
 \code{gaussian()}, to be passed to the \code{SuperLearner} or \code{glm}
@@ -70,16 +70,16 @@ formula may be input.}
 
 \item{glm_gr}{A character describing a formula to be used in the call to
 \code{glm} for the reduced-dimension propensity score. Ignored if
-\code{SL_gr!=NULL}. The formula should use the variable name \code{'Qn'} and 
+\code{SL_gr!=NULL}. The formula should use the variable name \code{'Qn'} and
 \code{'gn'} if \code{reduction='bivariate'} and \code{'Qn'} otherwise.}
 
-\item{guard}{A character vector indicating what pattern of misspecifications 
+\item{guard}{A character vector indicating what pattern of misspecifications
 to guard against. If \code{guard} contains \code{"Q"}, then the TMLE guards
 against misspecification of the outcome regression by estimating the
 reduced-dimension outcome regression specified by \code{glm_Qr} or
 \code{SL_Qr}. If \code{guard} contains \code{"g"} then the TMLE
 (additionally) guards against misspecification of the propensity score by
-estimating the reduced-dimension propensity score specified by \code{glm_gr} 
+estimating the reduced-dimension propensity score specified by \code{glm_gr}
 or \code{SL_gr}.}
 
 \item{reduction}{A character equal to \code{"univariate"} for a univariate
@@ -95,7 +95,7 @@ cross-validation is used. Alternatively, \code{cvFolds} may be entered as a
 vector of fold assignments for observations, in which case its length should
 be the same length as \code{Y}.}
 
-\item{maxIter}{A numeric that sets the maximum number of iterations the TMLE 
+\item{maxIter}{A numeric that sets the maximum number of iterations the TMLE
 can perform in its fluctuation step.}
 
 \item{tolIC}{A numeric that defines the stopping criteria based on the
@@ -112,11 +112,11 @@ submodel for the outcome regression should be fit using a single minimization
 latter was found to be more stable in simulations and is the default.}
 
 \item{parallel}{A boolean indicating whether to use parallelization based on
-\code{future} when estimating nuisance parameters. 
-Only useful if \code{cvFolds > 1}. By default, a \code{multiprocess} evaluation 
-scheme is invoked, using forked R processes
-(if supported on the OS) and background R sessions otherwise. Users may also
-register their own backends using the \code{future.batchtools} package.}
+\code{future} when estimating nuisance parameters.
+Only useful if \code{cvFolds > 1}. By default, a \code{multiprocess}
+evaluation scheme is invoked, using forked R processes (if supported on the
+OS) and background R sessions otherwise. Users may also register their own
+backends using the \code{future.batchtools} package.}
 
 \item{future_hpc}{A character string identifying a high-performance computing
 backend to be used with parallelization. This should match exactly one of the
@@ -148,17 +148,17 @@ An object of class \code{"drtmle"}.
        a doubly-robust covariance matrix}
  \item{\code{nuisance_drtmle}}{A \code{list} of the final TMLE estimates of
        the outcome regression (\code{$QnStar}), propensity score
-       (\code{$gnStar}), and reduced-dimension regressions (\code{$QrnStar}, 
+       (\code{$gnStar}), and reduced-dimension regressions (\code{$QrnStar},
        \code{$grnStar}) evaluated at the observed data values.}
  \item{\code{ic_drtmle}}{A \code{list} of the empirical mean of the efficient
        influence function (\code{$eif}) and the extra pieces of the influence
        function resulting from misspecification. All should be smaller than
        \code{tolIC} (unless \code{maxIter} was reached first). Also includes
-       a matrix of the influence function at the estimated nuisance parameters
-       evaluated at the observed data.}
+       a matrix of the influence function values at the estimated nuisance
+       parameters evaluated at the observed data.}
  \item{\code{aiptw_c}}{A \code{list} of doubly-robust point estimates and
        a non-doubly-robust covariance matrix. Theory does not guarantee
-       performance of inference for these estimators, but simulation studies 
+       performance of inference for these estimators, but simulation studies
        showed they often perform adequately.}
  \item{\code{nuisance_aiptw}}{A \code{list} of the initial estimates of the
        outcome regression, propensity score, and reduced-dimension
@@ -175,11 +175,11 @@ An object of class \code{"drtmle"}.
        \code{NULL} if \code{returnModels = FALSE}.}
  \item{\code{gnMod}}{The fitted object for the propensity score. Returns
        \code{NULL} if \code{returnModels = FALSE}.}
- \item{\code{QrnMod}}{The fitted object for the reduced-dimension regression 
+ \item{\code{QrnMod}}{The fitted object for the reduced-dimension regression
        that guards against misspecification of the outcome regression.
        Returns \code{NULL} if \code{returnModels = FALSE}.}
- \item{\code{grnMod}}{The fitted object for the reduced-dimension regression 
-       that guards against misspecification of the propensity score. Returns 
+ \item{\code{grnMod}}{The fitted object for the reduced-dimension regression
+       that guards against misspecification of the propensity score. Returns
        \code{NULL} if \code{returnModels = FALSE}.}
  \item{\code{a_0}}{The treatment levels that were requested for computation
        of covariate-adjusted means.}
@@ -200,7 +200,7 @@ Y <- rbinom(n, 1, plogis(W$W1*W$W2*A))
 # A quick example of drtmle:
 # We note that more flexible super learner libraries
 # are available, and that we recommend the user use more flexible
-# libraries for SL_Qr and SL_gr for general use. 
+# libraries for SL_Qr and SL_gr for general use.
 fit1 <- drtmle(W = W, A = A, Y = Y, a_0 = c(1,0),
                family=binomial(),
                stratify=FALSE,

--- a/man/estimateG.Rd
+++ b/man/estimateG.Rd
@@ -13,37 +13,37 @@ estimateG(A, W, DeltaY, DeltaA, SL_g, glm_g, a_0, tolg, stratify = FALSE,
 
 \item{W}{A \code{data.frame} of named covariates}
 
-\item{DeltaY}{Indicator of missing outcome (assumed to be equal to 0 if 
+\item{DeltaY}{Indicator of missing outcome (assumed to be equal to 0 if
 missing 1 if observed)}
 
-\item{DeltaA}{Indicator of missing treatment (assumed to be equal to 0 if 
+\item{DeltaA}{Indicator of missing treatment (assumed to be equal to 0 if
 missing 1 if observed)}
 
-\item{SL_g}{A vector of characters describing the super learner library to be 
-used for each of the regression (\code{DeltaA}, \code{A}, and \code{DeltaY}). 
-To use the same regression for each of the regressions (or if there is no 
+\item{SL_g}{A vector of characters describing the super learner library to be
+used for each of the regression (\code{DeltaA}, \code{A}, and \code{DeltaY}).
+To use the same regression for each of the regressions (or if there is no
 missing data in \code{A} nor \code{Y}), a single library may be input.}
 
-\item{glm_g}{A character describing a formula to be used in the call to 
+\item{glm_g}{A character describing a formula to be used in the call to
 \code{glm} for the propensity score.}
 
-\item{a_0}{A vector of fixed treatment values at which to return marginal 
+\item{a_0}{A vector of fixed treatment values at which to return marginal
 mean estimates.}
 
-\item{tolg}{A numeric indicating the minimum value for estimates of the 
+\item{tolg}{A numeric indicating the minimum value for estimates of the
 propensity score.}
 
-\item{stratify}{A \code{boolean} indicating whether to estimate the missing 
+\item{stratify}{A \code{boolean} indicating whether to estimate the missing
 outcome regression separately
-for observations with \code{A} equal to 0/1 (if \code{TRUE}) or to pool 
+for observations with \code{A} equal to 0/1 (if \code{TRUE}) or to pool
 across \code{A} (if \code{FALSE}).}
 
-\item{validRows}{A \code{list} of length \code{cvFolds} containing the row 
+\item{validRows}{A \code{list} of length \code{cvFolds} containing the row
 indexes of observations to include in validation fold.}
 
 \item{verbose}{A boolean indicating whether to print status updates.}
 
-\item{returnModels}{A boolean indicating whether to return model fits for the 
+\item{returnModels}{A boolean indicating whether to return model fits for the
 outcome regression, propensity score, and reduced-dimension regressions.}
 }
 \description{

--- a/man/estimateQ.Rd
+++ b/man/estimateQ.Rd
@@ -10,37 +10,37 @@ estimateQ(Y, A, W, DeltaA, DeltaY, SL_Q, glm_Q, a_0, stratify, family,
 \arguments{
 \item{Y}{A vector of continuous or binary outcomes.}
 
-\item{A}{A vector of binary treatment assignment (assumed to be equal to 0 or 
+\item{A}{A vector of binary treatment assignment (assumed to be equal to 0 or
 1).}
 
 \item{W}{A \code{data.frame} of named covariates.}
 
-\item{DeltaA}{Indicator of missing treatment (assumed to be equal to 0 if 
+\item{DeltaA}{Indicator of missing treatment (assumed to be equal to 0 if
 missing 1 if observed).}
 
-\item{DeltaY}{Indicator of missing outcome (assumed to be equal to 0 if 
+\item{DeltaY}{Indicator of missing outcome (assumed to be equal to 0 if
 missing 1 if observed).}
 
-\item{SL_Q}{A vector of characters or a list describing the Super Learner 
+\item{SL_Q}{A vector of characters or a list describing the Super Learner
 library to be used for the outcome regression.}
 
-\item{glm_Q}{A character describing a formula to be used in the call to 
+\item{glm_Q}{A character describing a formula to be used in the call to
 \code{glm} for the outcome regression.}
 
 \item{a_0}{A list of fixed treatment values}
 
-\item{stratify}{A \code{boolean} indicating whether to estimate the outcome 
-regression separately for observations with \code{A} equal to 0/1 (if 
+\item{stratify}{A \code{boolean} indicating whether to estimate the outcome
+regression separately for observations with \code{A} equal to 0/1 (if
 \code{TRUE}) or to pool across \code{A} (if \code{FALSE}).}
 
 \item{family}{A character passed to \code{SuperLearner}}
 
 \item{verbose}{A boolean indicating whether to print status updates.}
 
-\item{returnModels}{A boolean indicating whether to return model fits for the 
+\item{returnModels}{A boolean indicating whether to return model fits for the
 outcome regression, propensity score, and reduced-dimension regressions.}
 
-\item{validRows}{A \code{list} of length \code{cvFolds} containing the row 
+\item{validRows}{A \code{list} of length \code{cvFolds} containing the row
 indexes of observations to include in validation fold.}
 
 \item{...}{Additional arguments (not currently used)}

--- a/man/estimateQrn.Rd
+++ b/man/estimateQrn.Rd
@@ -15,38 +15,38 @@ estimateQrn(Y, A, W, DeltaA, DeltaY, Qn, gn, glm_Qr, SL_Qr,
 
 \item{W}{A \code{data.frame} of named covariates}
 
-\item{DeltaA}{Indicator of missing treatment (assumed to be equal to 0 if 
+\item{DeltaA}{Indicator of missing treatment (assumed to be equal to 0 if
 missing 1 if observed)}
 
-\item{DeltaY}{Indicator of missing outcome (assumed to be equal to 0 if 
+\item{DeltaY}{Indicator of missing outcome (assumed to be equal to 0 if
 missing 1 if observed)}
 
-\item{Qn}{A list of outcome regression estimates evaluated on observed data. 
-If NULL then 0 is used for all Qn (as is needed to estimate reduced dimension 
+\item{Qn}{A list of outcome regression estimates evaluated on observed data.
+If NULL then 0 is used for all Qn (as is needed to estimate reduced dimension
 regression for adaptive_iptw)}
 
-\item{gn}{A list of propensity regression estimates evaluated on observed 
+\item{gn}{A list of propensity regression estimates evaluated on observed
 data}
 
-\item{glm_Qr}{A character describing a formula to be used in the call to 
-\code{glm} for the first reduced-dimension regression. Ignored if 
+\item{glm_Qr}{A character describing a formula to be used in the call to
+\code{glm} for the first reduced-dimension regression. Ignored if
 \code{SL_gr!=NULL}.}
 
-\item{SL_Qr}{A vector of characters or a list describing the Super Learner 
+\item{SL_Qr}{A vector of characters or a list describing the Super Learner
 library to be used for the first reduced-dimension regression.}
 
-\item{family}{Should be gaussian() unless called from adaptive_iptw with 
+\item{family}{Should be gaussian() unless called from adaptive_iptw with
 binary \code{Y}.}
 
 \item{a_0}{A list of fixed treatment values.}
 
-\item{returnModels}{A boolean indicating whether to return model fits for the 
+\item{returnModels}{A boolean indicating whether to return model fits for the
 outcome regression, propensity score, and reduced-dimension regressions.}
 
-\item{validRows}{A \code{list} of length \code{cvFolds} containing the row 
+\item{validRows}{A \code{list} of length \code{cvFolds} containing the row
 indexes of observations to include in validation fold.}
 }
 \description{
-Estimates the reduced dimension regressions necessary for the  
+Estimates the reduced dimension regressions necessary for the
 fluctuations of g
 }

--- a/man/estimategrn.Rd
+++ b/man/estimategrn.Rd
@@ -15,39 +15,39 @@ estimategrn(Y, A, W, DeltaA, DeltaY, Qn, gn, SL_gr, tolg, glm_gr, a_0,
 
 \item{W}{A \code{data.frame} of named covariates.}
 
-\item{DeltaA}{Indicator of missing treatment (assumed to be equal to 0 if 
+\item{DeltaA}{Indicator of missing treatment (assumed to be equal to 0 if
 missing 1 if observed).}
 
-\item{DeltaY}{Indicator of missing outcome (assumed to be equal to 0 if 
+\item{DeltaY}{Indicator of missing outcome (assumed to be equal to 0 if
 missing 1 if observed).}
 
 \item{Qn}{A list of outcome regression estimates evaluated on observed data.}
 
-\item{gn}{A list of propensity regression estimates evaluated on observed 
+\item{gn}{A list of propensity regression estimates evaluated on observed
 data.}
 
-\item{SL_gr}{A vector of characters or a list describing the Super Learner 
+\item{SL_gr}{A vector of characters or a list describing the Super Learner
 library to be used for the reduced-dimension propensity score.}
 
-\item{tolg}{A numeric indicating the minimum value for estimates of the 
+\item{tolg}{A numeric indicating the minimum value for estimates of the
 propensity score.}
 
-\item{glm_gr}{A character describing a formula to be used in the call to 
-\code{glm} for the second reduced-dimension regression. Ignored if 
+\item{glm_gr}{A character describing a formula to be used in the call to
+\code{glm} for the second reduced-dimension regression. Ignored if
 \code{SL_gr!=NULL}.}
 
 \item{a_0}{A list of fixed treatment values .}
 
-\item{reduction}{A character equal to \code{'univariate'} for a univariate 
+\item{reduction}{A character equal to \code{'univariate'} for a univariate
 misspecification correction or \code{'bivariate'} for the bivariate version.}
 
-\item{returnModels}{A boolean indicating whether to return model fits for the 
+\item{returnModels}{A boolean indicating whether to return model fits for the
 outcome regression, propensity score, and reduced-dimension regressions.}
 
-\item{validRows}{A \code{list} of length \code{cvFolds} containing the row 
+\item{validRows}{A \code{list} of length \code{cvFolds} containing the row
 indexes of observations to include in validation fold.}
 }
 \description{
-Estimates the reduced dimension regressions necessary for the additional 
+Estimates the reduced dimension regressions necessary for the additional
 fluctuations.
 }

--- a/man/fluctuateG.Rd
+++ b/man/fluctuateG.Rd
@@ -29,7 +29,7 @@ fluctuateG(Y, A, W, DeltaY, DeltaA, a_0, gn, Qrn, tolg, coefTol = 1e+05)
 result as potentially the result of numeric instability.}
 }
 \description{
-Function called internally by drtmle to perform the fluctuation 
+Function called internally by drtmle to perform the fluctuation
 of the initial estimator of g (i.e., solves the new estimating eqn that results
 from misspecification of Q)
 }

--- a/man/fluctuateQ.Rd
+++ b/man/fluctuateQ.Rd
@@ -32,7 +32,7 @@ fluctuateQ(Y, A, W, DeltaY, DeltaA, Qn, gn, grn, a_0, reduction,
 result as potentially the result of numeric instability.}
 }
 \description{
-Function called internally by drtmle to perform simultaneous fluctuation 
-of the initial estimator of Q (i.e., solves both EIF estimating eqn and 
+Function called internally by drtmle to perform simultaneous fluctuation
+of the initial estimator of Q (i.e., solves both EIF estimating eqn and
 the new estimating eqn that results from misspecification of g)
 }

--- a/man/fluctuateQ1.Rd
+++ b/man/fluctuateQ1.Rd
@@ -24,6 +24,6 @@ fluctuateQ1(Y, A, W, DeltaA, DeltaY, Qn, gn, a_0)
 \item{a_0}{A list of fixed treatment values}
 }
 \description{
-Function called internally by drtmle to perform the first fluctuation 
+Function called internally by drtmle to perform the first fluctuation
 of the initial estimator of Q (i.e., solves the original EIF estimating eqn)
 }

--- a/man/fluctuateQ2.Rd
+++ b/man/fluctuateQ2.Rd
@@ -32,7 +32,7 @@ fluctuateQ2(Y, A, W, DeltaY, DeltaA, Qn, gn, grn, a_0, reduction,
 result as potentially the result of numeric instability.}
 }
 \description{
-Function called internally by drtmle to perform the second fluctuation 
+Function called internally by drtmle to perform the second fluctuation
 of the initial estimator of Q (i.e., solves the new estimating eqn that results
 from misspecification of g)
 }

--- a/man/method.CC_LS_mod.Rd
+++ b/man/method.CC_LS_mod.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/method_fixes.R
 \name{method.CC_LS_mod}
 \alias{method.CC_LS_mod}
-\title{Modification of convex combination least squares method 
+\title{Modification of convex combination least squares method
 for \code{SuperLearner} that doesn't fail with duplicated predictors.
 Issue reported to \code{SuperLearner} maintainers. This function will
 be deprecated when a more robust fix in the \code{SuperLearner} package
@@ -11,7 +11,7 @@ is implemented.}
 method.CC_LS_mod()
 }
 \description{
-Modification of convex combination least squares method 
+Modification of convex combination least squares method
 for \code{SuperLearner} that doesn't fail with duplicated predictors.
 Issue reported to \code{SuperLearner} maintainers. This function will
 be deprecated when a more robust fix in the \code{SuperLearner} package

--- a/man/plot.drtmle.Rd
+++ b/man/plot.drtmle.Rd
@@ -34,7 +34,7 @@ fit1 <- drtmle(W = W, A = A, Y = Y, a_0 = c(1,0),
                stratify=FALSE,
                SL_Q=c("SL.glm","SL.mean","SL.glm.interaction"),
                SL_g=c("SL.glm","SL.mean","SL.glm.interaction"),
-               SL_Qr="SL.npreg", SL_gr="SL.npreg", 
+               SL_Qr="SL.npreg", SL_gr="SL.npreg",
                maxIter = 1, returnModels = TRUE)
 # plot the reduced-dimension regression fits (not run)
 \dontrun{plot(fit1)}

--- a/man/wald_test.adaptive_iptw.Rd
+++ b/man/wald_test.adaptive_iptw.Rd
@@ -10,29 +10,29 @@
 \arguments{
 \item{object}{An object of class \code{"adaptive_iptw"}}
 
-\item{est}{A vector indicating for which estimators to return a 
-confidence interval. Possible estimators include the TMLE IPTW 
-(\code{"iptw_tmle"}, recommended), the one-step IPTW 
-(\code{"iptw_os"}, not recommended), the standard IPTW 
+\item{est}{A vector indicating for which estimators to return a
+confidence interval. Possible estimators include the TMLE IPTW
+(\code{"iptw_tmle"}, recommended), the one-step IPTW
+(\code{"iptw_os"}, not recommended), the standard IPTW
 (\code{"iptw"}, recommended only for comparison to the other two estimators).}
 
 \item{null}{The null hypothesis value(s).}
 
 \item{contrast}{This option specifies what parameter to return confidence intervals for.
 If \code{contrast=NULL}, then test the null hypothesis that the covariate-adjusted
-marginal means equal the value(s) specified in \code{null}. 
+marginal means equal the value(s) specified in \code{null}.
 \code{contrast} can also be a numeric vector of ones, negative ones,
 and zeros to define linear combinations of the various means (e.g., to estimate an average
-treatment effect, see examples). In this case, we test the null hypothesis that the 
-linear combination of means equals the value specified in \code{null}. 
+treatment effect, see examples). In this case, we test the null hypothesis that the
+linear combination of means equals the value specified in \code{null}.
 \code{contrast} can also be a list with named functions
 \code{f}, \code{h}, and \code{fh_grad}. The function \code{f} takes
-as input argument \code{eff} and specifies which transformation 
-of the effect measure to test. The function \code{h} defines the contrast 
+as input argument \code{eff} and specifies which transformation
+of the effect measure to test. The function \code{h} defines the contrast
 to be estimated and should take as input \code{est}, a vector
 of the same length as \code{object$a_0}, and output the desired contrast. The function
 \code{fh_grad} is the gradient of the function \code{h(f())}. The function
-computes a test of the null hypothesis that \code{h(f(object$est)) = null}. 
+computes a test of the null hypothesis that \code{h(f(object$est)) = null}.
 See examples.}
 
 \item{...}{Other options (not currently used).}
@@ -61,7 +61,7 @@ fit1 <- adaptive_iptw(W = W, A = A, Y = Y, a_0 = c(1,0),
 # get test that each mean = 0.5
 test_mean <- wald_test(fit1, null = 0.5)
 
-# get test that the ATE = 0 
+# get test that the ATE = 0
 ci_ATE <- ci(fit1, contrast = c(1,-1), null = 0)
 
 # get test for risk ratio = 1 on log scale

--- a/man/wald_test.drtmle.Rd
+++ b/man/wald_test.drtmle.Rd
@@ -10,31 +10,31 @@
 \arguments{
 \item{object}{An object of class \code{"drtmle"}}
 
-\item{est}{A vector indicating for which estimators to return a 
+\item{est}{A vector indicating for which estimators to return a
 confidence interval. Possible estimators include the TMLE with doubly robust
-inference (\code{"drtmle"}, recommended), the AIPTW with additional correction 
-for misspecification (\code{"aiptw_c"}, not recommended), the standard TMLE 
-(\code{"tmle"}, recommended only for comparison to "drtmle"), the standard 
-AIPTW (\code{"aiptw"}, recommended only for comparison to "drtmle"), and 
+inference (\code{"drtmle"}, recommended), the AIPTW with additional correction
+for misspecification (\code{"aiptw_c"}, not recommended), the standard TMLE
+(\code{"tmle"}, recommended only for comparison to "drtmle"), the standard
+AIPTW (\code{"aiptw"}, recommended only for comparison to "drtmle"), and
 G-computation (\code{"gcomp"}, not recommended).}
 
 \item{null}{The null hypothesis value.}
 
 \item{contrast}{This option specifies what parameter to return confidence intervals for.
 If \code{contrast=NULL}, then test the null hypothesis that the covariate-adjusted
-marginal means equal the value(s) specified in \code{null}. 
+marginal means equal the value(s) specified in \code{null}.
 \code{contrast} can also be a numeric vector of ones, negative ones,
 and zeros to define linear combinations of the various means (e.g., to estimate an average
-treatment effect, see examples). In this case, we test the null hypothesis that the 
-linear combination of means equals the value specified in \code{null}. 
+treatment effect, see examples). In this case, we test the null hypothesis that the
+linear combination of means equals the value specified in \code{null}.
 \code{contrast} can also be a list with named functions
 \code{f}, \code{h}, and \code{fh_grad}. The function \code{f} takes
-as input argument \code{eff} and specifies which transformation 
-of the effect measure to test. The function \code{h} defines the contrast 
+as input argument \code{eff} and specifies which transformation
+of the effect measure to test. The function \code{h} defines the contrast
 to be estimated and should take as input \code{est}, a vector
 of the same length as \code{object$a_0}, and output the desired contrast. The function
 \code{fh_grad} is the gradient of the function \code{h(f())}. The function
-computes a test of the null hypothesis that \code{h(f(object$est)) = null}. 
+computes a test of the null hypothesis that \code{h(f(object$est)) = null}.
 See examples.}
 
 \item{...}{Other options (not currently used).}

--- a/tests/testthat/test-adaptive_iptw-missingAY.R
+++ b/tests/testthat/test-adaptive_iptw-missingAY.R
@@ -5,25 +5,27 @@ library(testthat)
 
 # TO DO: Add tests for multiple treatment levels
 context("Testing adaptive_iptw works")
-test_that("adaptive_iptw works as expected with missing data",{
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	DeltaA <- 1-rbinom(n,1,plogis(-4 + W$W1 - W$W2))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	DeltaY <- 1-rbinom(n,1,plogis(-4 + W$W1 - A))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
-	Y[DeltaY == 0] <- NA
-	A[DeltaA == 0] <- NA
+test_that("adaptive_iptw works as expected with missing data", {
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  DeltaA <- 1 - rbinom(n, 1, plogis(-4 + W$W1 - W$W2))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  DeltaY <- 1 - rbinom(n, 1, plogis(-4 + W$W1 - A))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
+  Y[DeltaY == 0] <- NA
+  A[DeltaA == 0] <- NA
 
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y, 
-	               a_0 = c(0,1),
-                  glm_g="W1 + W2",
-                  glm_Qr="gn")
-	expect_true(all(!is.na(fit1$iptw_tmle$est)))
-	expect_true(all(!is.na(fit1$iptw_tmle$cov)))
-	expect_true(all(!is.na(fit1$iptw_os$est)))
-	expect_true(all(!is.na(fit1$iptw_os$cov)))
-	expect_true(all(!is.na(fit1$iptw$est)))
-	expect_true(class(fit1)=="adaptive_iptw")
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y,
+    a_0 = c(0, 1),
+    glm_g = "W1 + W2",
+    glm_Qr = "gn"
+  )
+  expect_true(all(!is.na(fit1$iptw_tmle$est)))
+  expect_true(all(!is.na(fit1$iptw_tmle$cov)))
+  expect_true(all(!is.na(fit1$iptw_os$est)))
+  expect_true(all(!is.na(fit1$iptw_os$cov)))
+  expect_true(all(!is.na(fit1$iptw$est)))
+  expect_true(class(fit1) == "adaptive_iptw")
 })

--- a/tests/testthat/test-adaptive_iptw.R
+++ b/tests/testthat/test-adaptive_iptw.R
@@ -6,62 +6,68 @@ library(foreach)
 context("Testing adaptive_iptw works")
 test_that("adaptive_iptw works as expected with parallel = TRUE", {
   skip_on_os("windows") # Windows doesn't support multicore (esp. Appveyor CI)
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y,
-	               a_0 = c(0,1),
-                  glm_g="W1 + W2",
-                  glm_Qr="gn",parallel = TRUE)
-	expect_true(all(!is.na(fit1$iptw_tmle$est)))
-	expect_true(all(!is.na(fit1$iptw_tmle$cov)))
-	expect_true(all(!is.na(fit1$iptw_os$est)))
-	expect_true(all(!is.na(fit1$iptw_os$cov)))
-	expect_true(all(!is.na(fit1$iptw$est)))
-	expect_true(all(!is.na(fit1$iptw$cov)))
-	expect_true(class(fit1)=="adaptive_iptw")
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y,
+    a_0 = c(0, 1),
+    glm_g = "W1 + W2",
+    glm_Qr = "gn", parallel = TRUE
+  )
+  expect_true(all(!is.na(fit1$iptw_tmle$est)))
+  expect_true(all(!is.na(fit1$iptw_tmle$cov)))
+  expect_true(all(!is.na(fit1$iptw_os$est)))
+  expect_true(all(!is.na(fit1$iptw_os$cov)))
+  expect_true(all(!is.na(fit1$iptw$est)))
+  expect_true(all(!is.na(fit1$iptw$cov)))
+  expect_true(class(fit1) == "adaptive_iptw")
 })
-test_that("adaptive_iptw works as expected",{
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+test_that("adaptive_iptw works as expected", {
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y,
-	               a_0 = c(0,1),
-                  glm_g="W1 + W2",
-                  glm_Qr="gn")
-	expect_true(all(!is.na(fit1$iptw_tmle$est)))
-	expect_true(all(!is.na(fit1$iptw_tmle$cov)))
-	expect_true(all(!is.na(fit1$iptw_os$est)))
-	expect_true(all(!is.na(fit1$iptw_os$cov)))
-	expect_true(all(!is.na(fit1$iptw$est)))
-	expect_true(all(!is.na(fit1$iptw$cov)))
-	expect_true(class(fit1)=="adaptive_iptw")
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y,
+    a_0 = c(0, 1),
+    glm_g = "W1 + W2",
+    glm_Qr = "gn"
+  )
+  expect_true(all(!is.na(fit1$iptw_tmle$est)))
+  expect_true(all(!is.na(fit1$iptw_tmle$cov)))
+  expect_true(all(!is.na(fit1$iptw_os$est)))
+  expect_true(all(!is.na(fit1$iptw_os$cov)))
+  expect_true(all(!is.na(fit1$iptw$est)))
+  expect_true(all(!is.na(fit1$iptw$cov)))
+  expect_true(class(fit1) == "adaptive_iptw")
 })
 
-test_that("adaptive_iptw works as expected with multi-level treatment",{
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2)) + rbinom(n, 1, 0.5)
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+test_that("adaptive_iptw works as expected with multi-level treatment", {
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2)) + rbinom(n, 1, 0.5)
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y,
-	               a_0 = c(0,1,2),
-                  SL_g="SL.glm",
-                  glm_Qr="gn")
-	expect_true(all(!is.na(fit1$iptw_tmle$est)))
-	expect_true(all(!is.na(fit1$iptw_tmle$cov)))
-	expect_true(all(!is.na(fit1$iptw_os$est)))
-	expect_true(all(!is.na(fit1$iptw_os$cov)))
-	expect_true(all(!is.na(fit1$iptw$est)))
-	expect_true(all(!is.na(fit1$iptw$cov)))
-	expect_true(length(fit1$iptw_tmle$est) == 3)
-	expect_true(length(fit1$iptw_os$est) == 3)
-	expect_true(class(fit1)=="adaptive_iptw")
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y,
+    a_0 = c(0, 1, 2),
+    SL_g = "SL.glm",
+    glm_Qr = "gn"
+  )
+  expect_true(all(!is.na(fit1$iptw_tmle$est)))
+  expect_true(all(!is.na(fit1$iptw_tmle$cov)))
+  expect_true(all(!is.na(fit1$iptw_os$est)))
+  expect_true(all(!is.na(fit1$iptw_os$cov)))
+  expect_true(all(!is.na(fit1$iptw$est)))
+  expect_true(all(!is.na(fit1$iptw$cov)))
+  expect_true(length(fit1$iptw_tmle$est) == 3)
+  expect_true(length(fit1$iptw_os$est) == 3)
+  expect_true(class(fit1) == "adaptive_iptw")
 })

--- a/tests/testthat/test-confint.R
+++ b/tests/testthat/test-confint.R
@@ -2,123 +2,147 @@ library(drtmle)
 library(SuperLearner)
 
 context("Testing ci.drtmle method ")
-test_that("ci.drtmle works as expected",{
-	# simulate data
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rbinom(n, 1, plogis(W$W1*W$W2*A))
-	# fit a drtmle
-	fit1 <- drtmle(W = W, A = A, Y = Y, a_0 = c(1,0),
-					  family=binomial(),
-	               stratify=FALSE,
-	               SL_Q="SL.glm",
-	               SL_g="SL.glm",
-	               SL_Qr="SL.glm",
-	               SL_gr="SL.glm")
+test_that("ci.drtmle works as expected", {
+  # simulate data
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rbinom(n, 1, plogis(W$W1 * W$W2 * A))
+  # fit a drtmle
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y, a_0 = c(1, 0),
+    family = binomial(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm"
+  )
 
-	# get confidence intervals for each mean for only drtmle
-	tmp <- ci(fit1)
-	# correct class
-	expect_true(class(tmp)=="ci.drtmle")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get confidence intervals for each mean for only drtmle
+  tmp <- ci(fit1)
+  # correct class
+  expect_true(class(tmp) == "ci.drtmle")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 
-	# get confidence intervals for each mean for drtmle and tmle
-	tmp <- ci(fit1, est = c("drtmle","tmle","aiptw","aiptw_c","gcomp"))
+  # get confidence intervals for each mean for drtmle and tmle
+  tmp <- ci(fit1, est = c("drtmle", "tmle", "aiptw", "aiptw_c", "gcomp"))
 
-	# correct class
-	expect_true(class(tmp)=="ci.drtmle")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
-	expect_true(length(tmp) == 5)
-	expect_true(all(names(tmp) == c("drtmle","tmle","aiptw","aiptw_c","gcomp")))
-	expect_true(nrow(tmp$drtmle) == 2)
-	expect_true(nrow(tmp$tmle) == 2)
+  # correct class
+  expect_true(class(tmp) == "ci.drtmle")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
+  expect_true(length(tmp) == 5)
+  expect_true(all(names(tmp) == c("drtmle", "tmle", "aiptw", "aiptw_c", "gcomp")))
+  expect_true(nrow(tmp$drtmle) == 2)
+  expect_true(nrow(tmp$tmle) == 2)
 
-	# get confidence intervals for ATE
-	tmp <- ci(fit1, contrast = c(1,-1))
-	# correct class
-	expect_true(class(tmp)=="ci.drtmle")
-	# correct row name
-	expect_true(row.names(tmp$drtmle) == "E[Y(1)]-E[Y(0)]")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get confidence intervals for ATE
+  tmp <- ci(fit1, contrast = c(1, -1))
+  # correct class
+  expect_true(class(tmp) == "ci.drtmle")
+  # correct row name
+  expect_true(row.names(tmp$drtmle) == "E[Y(1)]-E[Y(0)]")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 
-	# throws error if crazy contrast is put in 
-	expect_error(ci(fit1, contrast = c(10214,NA)))
+  # throws error if crazy contrast is put in
+  expect_error(ci(fit1, contrast = c(10214, NA)))
 
-	# get confidence intervals for risk ratio 
-	# by inputting own contrast function
-	# this computes CI on log scale and back transforms
-	myContrast <- list(f = function(eff){ log(eff) },
-	                   f_inv = function(eff){ exp(eff) },
-	                   h = function(est){ est[1]/est[2] },
-	                   fh_grad =  function(est){ c(1/est[1],-1/est[2]) })
-	tmp <- ci(fit1, contrast = myContrast)
-	expect_true(class(tmp)=="ci.drtmle")
-	expect_true(row.names(tmp$drtmle) == "user contrast")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get confidence intervals for risk ratio
+  # by inputting own contrast function
+  # this computes CI on log scale and back transforms
+  myContrast <- list(
+    f = function(eff) {
+      log(eff)
+    },
+    f_inv = function(eff) {
+      exp(eff)
+    },
+    h = function(est) {
+      est[1] / est[2]
+    },
+    fh_grad = function(est) {
+      c(1 / est[1], -1 / est[2])
+    }
+  )
+  tmp <- ci(fit1, contrast = myContrast)
+  expect_true(class(tmp) == "ci.drtmle")
+  expect_true(row.names(tmp$drtmle) == "user contrast")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 })
 
 ##### ADD TEST FOR ci.adaptive_iptw
 
 context("Testing ci.adaptive_iptw method ")
-test_that("ci.adaptive_iptw works as expected",{
-	# simulate data
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rbinom(n, 1, plogis(W$W1*W$W2*A))
-	# fit a drtmle
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y, a_0 = c(1,0),
-	               SL_g=c("SL.glm","SL.mean","SL.step"),
-	               SL_Qr="SL.glm")
+test_that("ci.adaptive_iptw works as expected", {
+  # simulate data
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rbinom(n, 1, plogis(W$W1 * W$W2 * A))
+  # fit a drtmle
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y, a_0 = c(1, 0),
+    SL_g = c("SL.glm", "SL.mean", "SL.step"),
+    SL_Qr = "SL.glm"
+  )
 
-	# get confidence intervals for each 
-	tmp <- ci(fit1)
-	# correct class
-	expect_true(class(tmp)=="ci.adaptive_iptw")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get confidence intervals for each
+  tmp <- ci(fit1)
+  # correct class
+  expect_true(class(tmp) == "ci.adaptive_iptw")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 
-	# get confidence intervals for each mean 
-	tmp <- ci(fit1, est = c("iptw_tmle","iptw_os"))
+  # get confidence intervals for each mean
+  tmp <- ci(fit1, est = c("iptw_tmle", "iptw_os"))
 
-	# correct class
-	expect_true(class(tmp)=="ci.adaptive_iptw")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
-	expect_true(length(tmp) == 2)
-	expect_true(all(names(tmp) == c("iptw_tmle","iptw_os")))
-	expect_true(nrow(tmp$iptw_tmle) == 2)
-	expect_true(nrow(tmp$iptw_os) == 2)
+  # correct class
+  expect_true(class(tmp) == "ci.adaptive_iptw")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
+  expect_true(length(tmp) == 2)
+  expect_true(all(names(tmp) == c("iptw_tmle", "iptw_os")))
+  expect_true(nrow(tmp$iptw_tmle) == 2)
+  expect_true(nrow(tmp$iptw_os) == 2)
 
-	# get confidence intervals for ATE
-	tmp <- ci(fit1, contrast = c(1,-1))
-	# correct class
-	expect_true(class(tmp)=="ci.adaptive_iptw")
-	# correct row name
-	expect_true(row.names(tmp$iptw_tmle) == "E[Y(1)]-E[Y(0)]")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get confidence intervals for ATE
+  tmp <- ci(fit1, contrast = c(1, -1))
+  # correct class
+  expect_true(class(tmp) == "ci.adaptive_iptw")
+  # correct row name
+  expect_true(row.names(tmp$iptw_tmle) == "E[Y(1)]-E[Y(0)]")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 
-	# throws error if crazy contrast is put in 
-	expect_error(ci(fit1, contrast = c(10214,NA)))
+  # throws error if crazy contrast is put in
+  expect_error(ci(fit1, contrast = c(10214, NA)))
 
-	# get confidence intervals for risk ratio 
-	# by inputting own contrast function
-	# this computes CI on log scale and back transforms
-	myContrast <- list(f = function(eff){ log(eff) },
-	                   f_inv = function(eff){ exp(eff) },
-	                   h = function(est){ est[1]/est[2] },
-	                   fh_grad =  function(est){ c(1/est[1],-1/est[2]) })
-	tmp <- ci(fit1, contrast = myContrast)
-	expect_true(class(tmp)=="ci.adaptive_iptw")
-	expect_true(row.names(tmp$iptw_tmle) == "user contrast")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get confidence intervals for risk ratio
+  # by inputting own contrast function
+  # this computes CI on log scale and back transforms
+  myContrast <- list(
+    f = function(eff) {
+      log(eff)
+    },
+    f_inv = function(eff) {
+      exp(eff)
+    },
+    h = function(est) {
+      est[1] / est[2]
+    },
+    fh_grad = function(est) {
+      c(1 / est[1], -1 / est[2])
+    }
+  )
+  tmp <- ci(fit1, contrast = myContrast)
+  expect_true(class(tmp) == "ci.adaptive_iptw")
+  expect_true(row.names(tmp$iptw_tmle) == "user contrast")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 })

--- a/tests/testthat/test-cvtmle.R
+++ b/tests/testthat/test-cvtmle.R
@@ -5,375 +5,404 @@ library(SuperLearner)
 context("Testing drtmle with cvFolds.")
 
 test_that("drtmle executes as expected with cvtmle and stratify = TRUE", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- drtmle(W = W, A = A, Y = Y, 
-	               cvFolds = 2, maxIter = 2,
-                   family=gaussian(),
-                      stratify=TRUE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="univariate")
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    cvFolds = 2, maxIter = 2,
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 
-	# bivariate reduction with 
-	# all GLMs + stratify 
-	fit2 <- drtmle(W = W, A = A, Y = Y,
-		               cvFolds = 2,  
-                   family=gaussian(),
-                      stratify=TRUE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="bivariate")
+  # bivariate reduction with
+  # all GLMs + stratify
+  fit2 <- drtmle(
+    W = W, A = A, Y = Y,
+    cvFolds = 2,
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
 
-	expect_true(is.numeric(fit2$gcomp$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$cov))
-	expect_true(is.numeric(fit2$drtmle$est))
-	expect_true(is.numeric(fit2$drtmle$cov))
-	expect_true(is.numeric(fit2$aiptw$est))
-	expect_true(is.numeric(fit2$aiptw$cov))
-	expect_true(is.numeric(fit2$aiptw_c$est))
-	expect_true(is.numeric(fit2$aiptw_c$cov))
+  expect_true(is.numeric(fit2$gcomp$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$cov))
+  expect_true(is.numeric(fit2$drtmle$est))
+  expect_true(is.numeric(fit2$drtmle$cov))
+  expect_true(is.numeric(fit2$aiptw$est))
+  expect_true(is.numeric(fit2$aiptw$cov))
+  expect_true(is.numeric(fit2$aiptw_c$est))
+  expect_true(is.numeric(fit2$aiptw_c$cov))
 
-	# univariate reduction with 
-	# all SL + stratify
-	system.time(
-	fit3 <- drtmle(W = W, A = A, Y = Y, 
-   	               cvFolds = 10, 
-               family=gaussian(),
-                  stratify=TRUE,
-                  SL_Q=c("SL.glm","SL.mean"),
-                  SL_g=c("SL.glm","SL.mean"),
-                  SL_Qr=c("SL.glm","SL.mean"),
-                  SL_gr=c("SL.glm","SL.mean"),
-                  guard=c("Q","g"),
-                  reduction="univariate")
-	)
-	
-	expect_true(is.numeric(fit3$gcomp$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$cov))
-	expect_true(is.numeric(fit3$drtmle$est))
-	expect_true(is.numeric(fit3$drtmle$cov))
-	expect_true(is.numeric(fit3$aiptw$est))
-	expect_true(is.numeric(fit3$aiptw$cov))
-	expect_true(is.numeric(fit3$aiptw_c$est))
-	expect_true(is.numeric(fit3$aiptw_c$cov))
+  # univariate reduction with
+  # all SL + stratify
+  system.time(
+    fit3 <- drtmle(
+      W = W, A = A, Y = Y,
+      cvFolds = 10,
+      family = gaussian(),
+      stratify = TRUE,
+      SL_Q = c("SL.glm", "SL.mean"),
+      SL_g = c("SL.glm", "SL.mean"),
+      SL_Qr = c("SL.glm", "SL.mean"),
+      SL_gr = c("SL.glm", "SL.mean"),
+      guard = c("Q", "g"),
+      reduction = "univariate"
+    )
+  )
 
-	#bivariate reduction with 
-	# all SL + stratify
-	fit4 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=TRUE,
-           cvFolds = 2, 
-              SL_Q=c("SL.glm","SL.step"),
-              SL_g=c("SL.glm","SL.step"),
-              SL_Qr=c("SL.glm","SL.mean"),
-              SL_gr=c("SL.glm","SL.mean"),
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit4$gcomp$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$cov))
-	expect_true(is.numeric(fit4$drtmle$est))
-	expect_true(is.numeric(fit4$drtmle$cov))
-	expect_true(is.numeric(fit4$aiptw$est))
-	expect_true(is.numeric(fit4$aiptw$cov))
-	expect_true(is.numeric(fit4$aiptw_c$est))
-	expect_true(is.numeric(fit4$aiptw_c$cov))
-	# bivariate reduction with 
-	# single SL + stratify
-	fit5 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-           cvFolds = 2, stratify=TRUE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit5$gcomp$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$cov))
-	expect_true(is.numeric(fit5$drtmle$est))
-	expect_true(is.numeric(fit5$drtmle$cov))
-	expect_true(is.numeric(fit5$aiptw$est))
-	expect_true(is.numeric(fit5$aiptw$cov))
-	expect_true(is.numeric(fit5$aiptw_c$est))
-	expect_true(is.numeric(fit5$aiptw_c$cov))
-	# univariate reduction with 
-	# single SL + stratify
-	fit6 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-           cvFolds = 2, 
-              stratify=TRUE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate")
-	expect_true(is.numeric(fit6$gcomp$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$cov))
-	expect_true(is.numeric(fit6$drtmle$est))
-	expect_true(is.numeric(fit6$drtmle$cov))
-	expect_true(is.numeric(fit6$aiptw$est))
-	expect_true(is.numeric(fit6$aiptw$cov))
-	expect_true(is.numeric(fit6$aiptw_c$est))
-	expect_true(is.numeric(fit6$aiptw_c$cov))
+  expect_true(is.numeric(fit3$gcomp$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$cov))
+  expect_true(is.numeric(fit3$drtmle$est))
+  expect_true(is.numeric(fit3$drtmle$cov))
+  expect_true(is.numeric(fit3$aiptw$est))
+  expect_true(is.numeric(fit3$aiptw$cov))
+  expect_true(is.numeric(fit3$aiptw_c$est))
+  expect_true(is.numeric(fit3$aiptw_c$cov))
+
+  # bivariate reduction with
+  # all SL + stratify
+  fit4 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    cvFolds = 2,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit4$gcomp$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$cov))
+  expect_true(is.numeric(fit4$drtmle$est))
+  expect_true(is.numeric(fit4$drtmle$cov))
+  expect_true(is.numeric(fit4$aiptw$est))
+  expect_true(is.numeric(fit4$aiptw$cov))
+  expect_true(is.numeric(fit4$aiptw_c$est))
+  expect_true(is.numeric(fit4$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify
+  fit5 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    cvFolds = 2, stratify = TRUE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit5$gcomp$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$cov))
+  expect_true(is.numeric(fit5$drtmle$est))
+  expect_true(is.numeric(fit5$drtmle$cov))
+  expect_true(is.numeric(fit5$aiptw$est))
+  expect_true(is.numeric(fit5$aiptw$cov))
+  expect_true(is.numeric(fit5$aiptw_c$est))
+  expect_true(is.numeric(fit5$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify
+  fit6 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    cvFolds = 2,
+    stratify = TRUE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit6$gcomp$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$cov))
+  expect_true(is.numeric(fit6$drtmle$est))
+  expect_true(is.numeric(fit6$drtmle$cov))
+  expect_true(is.numeric(fit6$aiptw$est))
+  expect_true(is.numeric(fit6$aiptw$cov))
+  expect_true(is.numeric(fit6$aiptw_c$est))
+  expect_true(is.numeric(fit6$aiptw_c$cov))
 })
 
 test_that("drtmle executes as expected with cv and stratify = FALSE", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- drtmle(W = W, A = A, Y = Y, 
-                   family=gaussian(),
-                   cvFolds = 2,
-                      stratify=FALSE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="univariate")
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    cvFolds = 2,
+    stratify = FALSE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 
-	# bivariate reduction with 
-	# all GLMs + stratify 
-	fit2 <- drtmle(W = W, A = A, Y = Y, 
-                   family=gaussian(),
-                      stratify=FALSE,
-                      cvFolds = 2,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="bivariate")
+  # bivariate reduction with
+  # all GLMs + stratify
+  fit2 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    cvFolds = 2,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
 
-	expect_true(is.numeric(fit2$gcomp$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$cov))
-	expect_true(is.numeric(fit2$drtmle$est))
-	expect_true(is.numeric(fit2$drtmle$cov))
-	expect_true(is.numeric(fit2$aiptw$est))
-	expect_true(is.numeric(fit2$aiptw$cov))
-	expect_true(is.numeric(fit2$aiptw_c$est))
-	expect_true(is.numeric(fit2$aiptw_c$cov))
+  expect_true(is.numeric(fit2$gcomp$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$cov))
+  expect_true(is.numeric(fit2$drtmle$est))
+  expect_true(is.numeric(fit2$drtmle$cov))
+  expect_true(is.numeric(fit2$aiptw$est))
+  expect_true(is.numeric(fit2$aiptw$cov))
+  expect_true(is.numeric(fit2$aiptw_c$est))
+  expect_true(is.numeric(fit2$aiptw_c$cov))
 
-	# univariate reduction with 
-	# all SL + stratify
-	fit3 <- drtmle(W = W, A = A, Y = Y, 
-               family=gaussian(),
-                  stratify=FALSE,
-                  cvFolds = 2,
-                  SL_Q=c("SL.glm","SL.step"),
-                  SL_g=c("SL.glm","SL.step"),
-                  SL_Qr=c("SL.glm","SL.mean"),
-                  SL_gr=c("SL.glm","SL.mean"),
-                  guard=c("Q","g"),
-                  reduction="univariate")
-	expect_true(is.numeric(fit3$gcomp$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$cov))
-	expect_true(is.numeric(fit3$drtmle$est))
-	expect_true(is.numeric(fit3$drtmle$cov))
-	expect_true(is.numeric(fit3$aiptw$est))
-	expect_true(is.numeric(fit3$aiptw$cov))
-	expect_true(is.numeric(fit3$aiptw_c$est))
-	expect_true(is.numeric(fit3$aiptw_c$cov))
+  # univariate reduction with
+  # all SL + stratify
+  fit3 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    cvFolds = 2,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit3$gcomp$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$cov))
+  expect_true(is.numeric(fit3$drtmle$est))
+  expect_true(is.numeric(fit3$drtmle$cov))
+  expect_true(is.numeric(fit3$aiptw$est))
+  expect_true(is.numeric(fit3$aiptw$cov))
+  expect_true(is.numeric(fit3$aiptw_c$est))
+  expect_true(is.numeric(fit3$aiptw_c$cov))
 
-	#bivariate reduction with 
-	# all SL + stratify
-	fit4 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=FALSE,
-              cvFolds = 2,
-              SL_Q=c("SL.glm","SL.step"),
-              SL_g=c("SL.glm","SL.step"),
-              SL_Qr=c("SL.glm","SL.mean"),
-              SL_gr=c("SL.glm","SL.mean"),
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit4$gcomp$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$cov))
-	expect_true(is.numeric(fit4$drtmle$est))
-	expect_true(is.numeric(fit4$drtmle$cov))
-	expect_true(is.numeric(fit4$aiptw$est))
-	expect_true(is.numeric(fit4$aiptw$cov))
-	expect_true(is.numeric(fit4$aiptw_c$est))
-	expect_true(is.numeric(fit4$aiptw_c$cov))
-	# bivariate reduction with 
-	# single SL + stratify
-	fit5 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-           cvFolds = 2,
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit5$gcomp$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$cov))
-	expect_true(is.numeric(fit5$drtmle$est))
-	expect_true(is.numeric(fit5$drtmle$cov))
-	expect_true(is.numeric(fit5$aiptw$est))
-	expect_true(is.numeric(fit5$aiptw$cov))
-	expect_true(is.numeric(fit5$aiptw_c$est))
-	expect_true(is.numeric(fit5$aiptw_c$cov))
-	# univariate reduction with 
-	# single SL + stratify
-	fit6 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=FALSE,
-              cvFolds = 2,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate")
-	expect_true(is.numeric(fit6$gcomp$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$cov))
-	expect_true(is.numeric(fit6$drtmle$est))
-	expect_true(is.numeric(fit6$drtmle$cov))
-	expect_true(is.numeric(fit6$aiptw$est))
-	expect_true(is.numeric(fit6$aiptw$cov))
-	expect_true(is.numeric(fit6$aiptw_c$est))
-	expect_true(is.numeric(fit6$aiptw_c$cov))
+  # bivariate reduction with
+  # all SL + stratify
+  fit4 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    cvFolds = 2,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit4$gcomp$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$cov))
+  expect_true(is.numeric(fit4$drtmle$est))
+  expect_true(is.numeric(fit4$drtmle$cov))
+  expect_true(is.numeric(fit4$aiptw$est))
+  expect_true(is.numeric(fit4$aiptw$cov))
+  expect_true(is.numeric(fit4$aiptw_c$est))
+  expect_true(is.numeric(fit4$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify
+  fit5 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    cvFolds = 2,
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit5$gcomp$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$cov))
+  expect_true(is.numeric(fit5$drtmle$est))
+  expect_true(is.numeric(fit5$drtmle$cov))
+  expect_true(is.numeric(fit5$aiptw$est))
+  expect_true(is.numeric(fit5$aiptw$cov))
+  expect_true(is.numeric(fit5$aiptw_c$est))
+  expect_true(is.numeric(fit5$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify
+  fit6 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    cvFolds = 2,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit6$gcomp$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$cov))
+  expect_true(is.numeric(fit6$drtmle$est))
+  expect_true(is.numeric(fit6$drtmle$cov))
+  expect_true(is.numeric(fit6$aiptw$est))
+  expect_true(is.numeric(fit6$aiptw$cov))
+  expect_true(is.numeric(fit6$aiptw_c$est))
+  expect_true(is.numeric(fit6$aiptw_c$cov))
 
-	# univariate reduction with 
-	# single SL + stratify + Qsteps = 1
-	fit7 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-           cvFolds = 2,
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit7$gcomp$est))
-	expect_true(is.numeric(fit7$tmle$est))
-	expect_true(is.numeric(fit7$tmle$est))
-	expect_true(is.numeric(fit7$tmle$cov))
-	expect_true(is.numeric(fit7$drtmle$est))
-	expect_true(is.numeric(fit7$drtmle$cov))
-	expect_true(is.numeric(fit7$aiptw$est))
-	expect_true(is.numeric(fit7$aiptw$cov))
-	expect_true(is.numeric(fit7$aiptw_c$est))
-	expect_true(is.numeric(fit7$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify + Qsteps = 1
+  fit7 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    cvFolds = 2,
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit7$gcomp$est))
+  expect_true(is.numeric(fit7$tmle$est))
+  expect_true(is.numeric(fit7$tmle$est))
+  expect_true(is.numeric(fit7$tmle$cov))
+  expect_true(is.numeric(fit7$drtmle$est))
+  expect_true(is.numeric(fit7$drtmle$cov))
+  expect_true(is.numeric(fit7$aiptw$est))
+  expect_true(is.numeric(fit7$aiptw$cov))
+  expect_true(is.numeric(fit7$aiptw_c$est))
+  expect_true(is.numeric(fit7$aiptw_c$cov))
 
-	# bivariate reduction with 
-	# single SL + stratify + Qsteps = 1
-	fit8 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-           cvFolds = 2,
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit8$gcomp$est))
-	expect_true(is.numeric(fit8$tmle$est))
-	expect_true(is.numeric(fit8$tmle$est))
-	expect_true(is.numeric(fit8$tmle$cov))
-	expect_true(is.numeric(fit8$drtmle$est))
-	expect_true(is.numeric(fit8$drtmle$cov))
-	expect_true(is.numeric(fit8$aiptw$est))
-	expect_true(is.numeric(fit8$aiptw$cov))
-	expect_true(is.numeric(fit8$aiptw_c$est))
-	expect_true(is.numeric(fit8$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify + Qsteps = 1
+  fit8 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    cvFolds = 2,
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit8$gcomp$est))
+  expect_true(is.numeric(fit8$tmle$est))
+  expect_true(is.numeric(fit8$tmle$est))
+  expect_true(is.numeric(fit8$tmle$cov))
+  expect_true(is.numeric(fit8$drtmle$est))
+  expect_true(is.numeric(fit8$drtmle$cov))
+  expect_true(is.numeric(fit8$aiptw$est))
+  expect_true(is.numeric(fit8$aiptw$cov))
+  expect_true(is.numeric(fit8$aiptw_c$est))
+  expect_true(is.numeric(fit8$aiptw_c$cov))
 
-	# give one a go with family = binomial()
-	# bivariate reduction with 
-	# single SL + stratify + Qsteps = 1
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rbinom(n, 1, plogis(W$W1*W$W2*A))
+  # give one a go with family = binomial()
+  # bivariate reduction with
+  # single SL + stratify + Qsteps = 1
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rbinom(n, 1, plogis(W$W1 * W$W2 * A))
 
-	fit9 <- drtmle(W = W, A = A, Y = Y, 
-           family=binomial(),
-              stratify=FALSE,
-              cvFolds = 2,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit9$gcomp$est))
-	expect_true(is.numeric(fit9$tmle$est))
-	expect_true(is.numeric(fit9$tmle$est))
-	expect_true(is.numeric(fit9$tmle$cov))
-	expect_true(is.numeric(fit9$drtmle$est))
-	expect_true(is.numeric(fit9$drtmle$cov))
-	expect_true(is.numeric(fit9$aiptw$est))
-	expect_true(is.numeric(fit9$aiptw$cov))
-	expect_true(is.numeric(fit9$aiptw_c$est))
-	expect_true(is.numeric(fit9$aiptw_c$cov))
-
+  fit9 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = binomial(),
+    stratify = FALSE,
+    cvFolds = 2,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit9$gcomp$est))
+  expect_true(is.numeric(fit9$tmle$est))
+  expect_true(is.numeric(fit9$tmle$est))
+  expect_true(is.numeric(fit9$tmle$cov))
+  expect_true(is.numeric(fit9$drtmle$est))
+  expect_true(is.numeric(fit9$drtmle$cov))
+  expect_true(is.numeric(fit9$aiptw$est))
+  expect_true(is.numeric(fit9$aiptw$cov))
+  expect_true(is.numeric(fit9$aiptw_c$est))
+  expect_true(is.numeric(fit9$aiptw_c$cov))
 })

--- a/tests/testthat/test-drtmle-missingAY.R
+++ b/tests/testthat/test-drtmle-missingAY.R
@@ -8,378 +8,408 @@ library(testthat)
 context("Testing drtmle function with missing outcomes and treatments")
 
 test_that("drtmle executes as expected with stratify = TRUE", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	DeltaA <- 1-rbinom(n,1,plogis(-4 + W$W1 - W$W2))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	DeltaY <- 1-rbinom(n,1,plogis(-4 + W$W1 - A))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
-	Y[DeltaY == 0] <- NA
-	A[DeltaA == 0] <- NA
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  DeltaA <- 1 - rbinom(n, 1, plogis(-4 + W$W1 - W$W2))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  DeltaY <- 1 - rbinom(n, 1, plogis(-4 + W$W1 - A))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
+  Y[DeltaY == 0] <- NA
+  A[DeltaA == 0] <- NA
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- drtmle(W = W, A = A, Y = Y,
-	               DeltaY = DeltaY, 
-	               DeltaA = DeltaA, 
-                   family=gaussian(),
-                   stratify=FALSE,
-                   glm_Q="W1 + W2",
-                   glm_g=list(DeltaA = "W1 + W2",
-                              DeltaY = "W1 + W2", 
-                              A = "W1 + W2"),
-                   glm_Qr="gn",
-  	               glm_gr="Qn",
-                   guard=c("Q","g"),
-                   reduction="univariate")
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    DeltaY = DeltaY,
+    DeltaA = DeltaA,
+    family = gaussian(),
+    stratify = FALSE,
+    glm_Q = "W1 + W2",
+    glm_g = list(
+      DeltaA = "W1 + W2",
+      DeltaY = "W1 + W2",
+      A = "W1 + W2"
+    ),
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 
-	# bivariate reduction with 
-	# all GLMs + stratify 
-	fit2 <- drtmle(W = W, A = A, Y = Y, 
-                   family=gaussian(),
-                      stratify=TRUE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="bivariate")
+  # bivariate reduction with
+  # all GLMs + stratify
+  fit2 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
 
-	expect_true(is.numeric(fit2$gcomp$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$cov))
-	expect_true(is.numeric(fit2$drtmle$est))
-	expect_true(is.numeric(fit2$drtmle$cov))
-	expect_true(is.numeric(fit2$aiptw$est))
-	expect_true(is.numeric(fit2$aiptw$cov))
-	expect_true(is.numeric(fit2$aiptw_c$est))
-	expect_true(is.numeric(fit2$aiptw_c$cov))
+  expect_true(is.numeric(fit2$gcomp$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$cov))
+  expect_true(is.numeric(fit2$drtmle$est))
+  expect_true(is.numeric(fit2$drtmle$cov))
+  expect_true(is.numeric(fit2$aiptw$est))
+  expect_true(is.numeric(fit2$aiptw$cov))
+  expect_true(is.numeric(fit2$aiptw_c$est))
+  expect_true(is.numeric(fit2$aiptw_c$cov))
 
-	# univariate reduction with 
-	# all SL + stratify
-	fit3 <- drtmle(W = W, A = A, Y = Y, 
-               family=gaussian(),
-                  stratify=TRUE,
-                  SL_Q=c("SL.glm","SL.step"),
-                  SL_g=c("SL.glm","SL.step"),
-                  SL_Qr=c("SL.glm","SL.mean"),
-                  SL_gr=c("SL.glm","SL.mean"),
-                  guard=c("Q","g"),
-                  reduction="univariate")
-	expect_true(is.numeric(fit3$gcomp$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$cov))
-	expect_true(is.numeric(fit3$drtmle$est))
-	expect_true(is.numeric(fit3$drtmle$cov))
-	expect_true(is.numeric(fit3$aiptw$est))
-	expect_true(is.numeric(fit3$aiptw$cov))
-	expect_true(is.numeric(fit3$aiptw_c$est))
-	expect_true(is.numeric(fit3$aiptw_c$cov))
+  # univariate reduction with
+  # all SL + stratify
+  fit3 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit3$gcomp$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$cov))
+  expect_true(is.numeric(fit3$drtmle$est))
+  expect_true(is.numeric(fit3$drtmle$cov))
+  expect_true(is.numeric(fit3$aiptw$est))
+  expect_true(is.numeric(fit3$aiptw$cov))
+  expect_true(is.numeric(fit3$aiptw_c$est))
+  expect_true(is.numeric(fit3$aiptw_c$cov))
 
-	#bivariate reduction with 
-	# all SL + stratify
-	fit4 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=TRUE,
-              SL_Q=c("SL.glm","SL.step"),
-              SL_g=c("SL.glm","SL.step"),
-              SL_Qr=c("SL.glm","SL.mean"),
-              SL_gr=c("SL.glm","SL.mean"),
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit4$gcomp$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$cov))
-	expect_true(is.numeric(fit4$drtmle$est))
-	expect_true(is.numeric(fit4$drtmle$cov))
-	expect_true(is.numeric(fit4$aiptw$est))
-	expect_true(is.numeric(fit4$aiptw$cov))
-	expect_true(is.numeric(fit4$aiptw_c$est))
-	expect_true(is.numeric(fit4$aiptw_c$cov))
-	# bivariate reduction with 
-	# single SL + stratify
-	fit5 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=TRUE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit5$gcomp$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$cov))
-	expect_true(is.numeric(fit5$drtmle$est))
-	expect_true(is.numeric(fit5$drtmle$cov))
-	expect_true(is.numeric(fit5$aiptw$est))
-	expect_true(is.numeric(fit5$aiptw$cov))
-	expect_true(is.numeric(fit5$aiptw_c$est))
-	expect_true(is.numeric(fit5$aiptw_c$cov))
-	# univariate reduction with 
-	# single SL + stratify
-	fit6 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=TRUE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate")
-	expect_true(is.numeric(fit6$gcomp$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$cov))
-	expect_true(is.numeric(fit6$drtmle$est))
-	expect_true(is.numeric(fit6$drtmle$cov))
-	expect_true(is.numeric(fit6$aiptw$est))
-	expect_true(is.numeric(fit6$aiptw$cov))
-	expect_true(is.numeric(fit6$aiptw_c$est))
-	expect_true(is.numeric(fit6$aiptw_c$cov))
-
+  # bivariate reduction with
+  # all SL + stratify
+  fit4 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit4$gcomp$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$cov))
+  expect_true(is.numeric(fit4$drtmle$est))
+  expect_true(is.numeric(fit4$drtmle$cov))
+  expect_true(is.numeric(fit4$aiptw$est))
+  expect_true(is.numeric(fit4$aiptw$cov))
+  expect_true(is.numeric(fit4$aiptw_c$est))
+  expect_true(is.numeric(fit4$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify
+  fit5 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit5$gcomp$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$cov))
+  expect_true(is.numeric(fit5$drtmle$est))
+  expect_true(is.numeric(fit5$drtmle$cov))
+  expect_true(is.numeric(fit5$aiptw$est))
+  expect_true(is.numeric(fit5$aiptw$cov))
+  expect_true(is.numeric(fit5$aiptw_c$est))
+  expect_true(is.numeric(fit5$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify
+  fit6 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit6$gcomp$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$cov))
+  expect_true(is.numeric(fit6$drtmle$est))
+  expect_true(is.numeric(fit6$drtmle$cov))
+  expect_true(is.numeric(fit6$aiptw$est))
+  expect_true(is.numeric(fit6$aiptw$cov))
+  expect_true(is.numeric(fit6$aiptw_c$est))
+  expect_true(is.numeric(fit6$aiptw_c$cov))
 })
 
 
-#--------------------------------------------------------------------
+# --------------------------------------------------------------------
 
 test_that("drtmle executes as expected with stratify = FALSE", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	DeltaA <- 1-rbinom(n,1,plogis(-4 + W$W1 - W$W2))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	DeltaY <- 1-rbinom(n,1,plogis(-4 + W$W1 - A))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
-	Y[DeltaY == 0] <- NA
-	A[DeltaA == 0] <- NA
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  DeltaA <- 1 - rbinom(n, 1, plogis(-4 + W$W1 - W$W2))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  DeltaY <- 1 - rbinom(n, 1, plogis(-4 + W$W1 - A))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
+  Y[DeltaY == 0] <- NA
+  A[DeltaA == 0] <- NA
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- drtmle(W = W, A = A, Y = Y, 
-                   family=gaussian(),
-                      stratify=FALSE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="univariate")
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 
-	# bivariate reduction with 
-	# all GLMs + stratify 
-	fit2 <- drtmle(W = W, A = A, Y = Y, 
-                   family=gaussian(),
-                      stratify=FALSE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="bivariate")
+  # bivariate reduction with
+  # all GLMs + stratify
+  fit2 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
 
-	expect_true(is.numeric(fit2$gcomp$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$cov))
-	expect_true(is.numeric(fit2$drtmle$est))
-	expect_true(is.numeric(fit2$drtmle$cov))
-	expect_true(is.numeric(fit2$aiptw$est))
-	expect_true(is.numeric(fit2$aiptw$cov))
-	expect_true(is.numeric(fit2$aiptw_c$est))
-	expect_true(is.numeric(fit2$aiptw_c$cov))
+  expect_true(is.numeric(fit2$gcomp$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$cov))
+  expect_true(is.numeric(fit2$drtmle$est))
+  expect_true(is.numeric(fit2$drtmle$cov))
+  expect_true(is.numeric(fit2$aiptw$est))
+  expect_true(is.numeric(fit2$aiptw$cov))
+  expect_true(is.numeric(fit2$aiptw_c$est))
+  expect_true(is.numeric(fit2$aiptw_c$cov))
 
-	# univariate reduction with 
-	# all SL + stratify
-	fit3 <- drtmle(W = W, A = A, Y = Y, 
-               family=gaussian(),
-                  stratify=FALSE,
-                  SL_Q=c("SL.glm","SL.step"),
-                  SL_g=c("SL.glm","SL.step"),
-                  SL_Qr=c("SL.glm","SL.mean"),
-                  SL_gr=c("SL.glm","SL.mean"),
-                  guard=c("Q","g"),
-                  reduction="univariate")
-	expect_true(is.numeric(fit3$gcomp$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$cov))
-	expect_true(is.numeric(fit3$drtmle$est))
-	expect_true(is.numeric(fit3$drtmle$cov))
-	expect_true(is.numeric(fit3$aiptw$est))
-	expect_true(is.numeric(fit3$aiptw$cov))
-	expect_true(is.numeric(fit3$aiptw_c$est))
-	expect_true(is.numeric(fit3$aiptw_c$cov))
+  # univariate reduction with
+  # all SL + stratify
+  fit3 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit3$gcomp$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$cov))
+  expect_true(is.numeric(fit3$drtmle$est))
+  expect_true(is.numeric(fit3$drtmle$cov))
+  expect_true(is.numeric(fit3$aiptw$est))
+  expect_true(is.numeric(fit3$aiptw$cov))
+  expect_true(is.numeric(fit3$aiptw_c$est))
+  expect_true(is.numeric(fit3$aiptw_c$cov))
 
-	#bivariate reduction with 
-	# all SL + stratify
-	fit4 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q=c("SL.glm","SL.step"),
-              SL_g=c("SL.glm","SL.step"),
-              SL_Qr=c("SL.glm","SL.mean"),
-              SL_gr=c("SL.glm","SL.mean"),
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit4$gcomp$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$cov))
-	expect_true(is.numeric(fit4$drtmle$est))
-	expect_true(is.numeric(fit4$drtmle$cov))
-	expect_true(is.numeric(fit4$aiptw$est))
-	expect_true(is.numeric(fit4$aiptw$cov))
-	expect_true(is.numeric(fit4$aiptw_c$est))
-	expect_true(is.numeric(fit4$aiptw_c$cov))
-	# bivariate reduction with 
-	# single SL + stratify
-	fit5 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit5$gcomp$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$cov))
-	expect_true(is.numeric(fit5$drtmle$est))
-	expect_true(is.numeric(fit5$drtmle$cov))
-	expect_true(is.numeric(fit5$aiptw$est))
-	expect_true(is.numeric(fit5$aiptw$cov))
-	expect_true(is.numeric(fit5$aiptw_c$est))
-	expect_true(is.numeric(fit5$aiptw_c$cov))
-	# univariate reduction with 
-	# single SL + stratify
-	fit6 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate")
-	expect_true(is.numeric(fit6$gcomp$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$cov))
-	expect_true(is.numeric(fit6$drtmle$est))
-	expect_true(is.numeric(fit6$drtmle$cov))
-	expect_true(is.numeric(fit6$aiptw$est))
-	expect_true(is.numeric(fit6$aiptw$cov))
-	expect_true(is.numeric(fit6$aiptw_c$est))
-	expect_true(is.numeric(fit6$aiptw_c$cov))
+  # bivariate reduction with
+  # all SL + stratify
+  fit4 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit4$gcomp$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$cov))
+  expect_true(is.numeric(fit4$drtmle$est))
+  expect_true(is.numeric(fit4$drtmle$cov))
+  expect_true(is.numeric(fit4$aiptw$est))
+  expect_true(is.numeric(fit4$aiptw$cov))
+  expect_true(is.numeric(fit4$aiptw_c$est))
+  expect_true(is.numeric(fit4$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify
+  fit5 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit5$gcomp$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$cov))
+  expect_true(is.numeric(fit5$drtmle$est))
+  expect_true(is.numeric(fit5$drtmle$cov))
+  expect_true(is.numeric(fit5$aiptw$est))
+  expect_true(is.numeric(fit5$aiptw$cov))
+  expect_true(is.numeric(fit5$aiptw_c$est))
+  expect_true(is.numeric(fit5$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify
+  fit6 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit6$gcomp$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$cov))
+  expect_true(is.numeric(fit6$drtmle$est))
+  expect_true(is.numeric(fit6$drtmle$cov))
+  expect_true(is.numeric(fit6$aiptw$est))
+  expect_true(is.numeric(fit6$aiptw$cov))
+  expect_true(is.numeric(fit6$aiptw_c$est))
+  expect_true(is.numeric(fit6$aiptw_c$cov))
 
-	# univariate reduction with 
-	# single SL + stratify + Qsteps = 1
-	fit7 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit7$gcomp$est))
-	expect_true(is.numeric(fit7$tmle$est))
-	expect_true(is.numeric(fit7$tmle$est))
-	expect_true(is.numeric(fit7$tmle$cov))
-	expect_true(is.numeric(fit7$drtmle$est))
-	expect_true(is.numeric(fit7$drtmle$cov))
-	expect_true(is.numeric(fit7$aiptw$est))
-	expect_true(is.numeric(fit7$aiptw$cov))
-	expect_true(is.numeric(fit7$aiptw_c$est))
-	expect_true(is.numeric(fit7$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify + Qsteps = 1
+  fit7 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit7$gcomp$est))
+  expect_true(is.numeric(fit7$tmle$est))
+  expect_true(is.numeric(fit7$tmle$est))
+  expect_true(is.numeric(fit7$tmle$cov))
+  expect_true(is.numeric(fit7$drtmle$est))
+  expect_true(is.numeric(fit7$drtmle$cov))
+  expect_true(is.numeric(fit7$aiptw$est))
+  expect_true(is.numeric(fit7$aiptw$cov))
+  expect_true(is.numeric(fit7$aiptw_c$est))
+  expect_true(is.numeric(fit7$aiptw_c$cov))
 
-	# bivariate reduction with 
-	# single SL + stratify + Qsteps = 1
-	fit8 <- drtmle(W = W, A = A, Y = Y, 
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit8$gcomp$est))
-	expect_true(is.numeric(fit8$tmle$est))
-	expect_true(is.numeric(fit8$tmle$est))
-	expect_true(is.numeric(fit8$tmle$cov))
-	expect_true(is.numeric(fit8$drtmle$est))
-	expect_true(is.numeric(fit8$drtmle$cov))
-	expect_true(is.numeric(fit8$aiptw$est))
-	expect_true(is.numeric(fit8$aiptw$cov))
-	expect_true(is.numeric(fit8$aiptw_c$est))
-	expect_true(is.numeric(fit8$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify + Qsteps = 1
+  fit8 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit8$gcomp$est))
+  expect_true(is.numeric(fit8$tmle$est))
+  expect_true(is.numeric(fit8$tmle$est))
+  expect_true(is.numeric(fit8$tmle$cov))
+  expect_true(is.numeric(fit8$drtmle$est))
+  expect_true(is.numeric(fit8$drtmle$cov))
+  expect_true(is.numeric(fit8$aiptw$est))
+  expect_true(is.numeric(fit8$aiptw$cov))
+  expect_true(is.numeric(fit8$aiptw_c$est))
+  expect_true(is.numeric(fit8$aiptw_c$cov))
 
-	# give one a go with family = binomial()
-	# bivariate reduction with 
-	# single SL + stratify + Qsteps = 1
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	DeltaA <- 1-rbinom(n,1,plogis(-4 + W$W1 - W$W2))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	DeltaY <- 1-rbinom(n,1,plogis(-4 + W$W1 - A))
-	Y <- rbinom(n, 1, plogis(W$W1*W$W2*A))
-	Y[DeltaY == 0] <- NA
-	A[DeltaA == 0] <- NA
+  # give one a go with family = binomial()
+  # bivariate reduction with
+  # single SL + stratify + Qsteps = 1
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  DeltaA <- 1 - rbinom(n, 1, plogis(-4 + W$W1 - W$W2))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  DeltaY <- 1 - rbinom(n, 1, plogis(-4 + W$W1 - A))
+  Y <- rbinom(n, 1, plogis(W$W1 * W$W2 * A))
+  Y[DeltaY == 0] <- NA
+  A[DeltaA == 0] <- NA
 
-	fit9 <- drtmle(W = W, A = A, Y = Y, 
-           family=binomial(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit9$gcomp$est))
-	expect_true(is.numeric(fit9$tmle$est))
-	expect_true(is.numeric(fit9$tmle$est))
-	expect_true(is.numeric(fit9$tmle$cov))
-	expect_true(is.numeric(fit9$drtmle$est))
-	expect_true(is.numeric(fit9$drtmle$cov))
-	expect_true(is.numeric(fit9$aiptw$est))
-	expect_true(is.numeric(fit9$aiptw$cov))
-	expect_true(is.numeric(fit9$aiptw_c$est))
-	expect_true(is.numeric(fit9$aiptw_c$cov))
-
+  fit9 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = binomial(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit9$gcomp$est))
+  expect_true(is.numeric(fit9$tmle$est))
+  expect_true(is.numeric(fit9$tmle$est))
+  expect_true(is.numeric(fit9$tmle$cov))
+  expect_true(is.numeric(fit9$drtmle$est))
+  expect_true(is.numeric(fit9$drtmle$cov))
+  expect_true(is.numeric(fit9$aiptw$est))
+  expect_true(is.numeric(fit9$aiptw$cov))
+  expect_true(is.numeric(fit9$aiptw_c$est))
+  expect_true(is.numeric(fit9$aiptw_c$cov))
 })

--- a/tests/testthat/test-drtmle.R
+++ b/tests/testthat/test-drtmle.R
@@ -4,394 +4,423 @@ library(SuperLearner)
 context("Testing drtmle function")
 test_that("drtmle executes as expected with parallel = TRUE", {
   skip_on_os("windows") # Windows doesn't support multicore (esp. Appveyor CI)
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- drtmle(W = W, A = A, Y = Y,
-	               parallel = TRUE,
-                       family=gaussian(),
-                       stratify=TRUE,
-                       glm_Q="W1 + W2",
-                       glm_g="W1 + W2",
-                       glm_Qr="gn",
-                       glm_gr="Qn",
-                       guard=c("Q","g"),
-                       reduction="univariate")
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    parallel = TRUE,
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
-
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 })
 test_that("drtmle executes as expected with stratify = TRUE", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- drtmle(W = W, A = A, Y = Y,
-                   family=gaussian(),
-                      stratify=TRUE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="univariate")
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 
-	# bivariate reduction with
-	# all GLMs + stratify
-	fit2 <- drtmle(W = W, A = A, Y = Y,
-                   family=gaussian(),
-                      stratify=TRUE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="bivariate")
+  # bivariate reduction with
+  # all GLMs + stratify
+  fit2 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
 
-	expect_true(is.numeric(fit2$gcomp$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$cov))
-	expect_true(is.numeric(fit2$drtmle$est))
-	expect_true(is.numeric(fit2$drtmle$cov))
-	expect_true(is.numeric(fit2$aiptw$est))
-	expect_true(is.numeric(fit2$aiptw$cov))
-	expect_true(is.numeric(fit2$aiptw_c$est))
-	expect_true(is.numeric(fit2$aiptw_c$cov))
+  expect_true(is.numeric(fit2$gcomp$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$cov))
+  expect_true(is.numeric(fit2$drtmle$est))
+  expect_true(is.numeric(fit2$drtmle$cov))
+  expect_true(is.numeric(fit2$aiptw$est))
+  expect_true(is.numeric(fit2$aiptw$cov))
+  expect_true(is.numeric(fit2$aiptw_c$est))
+  expect_true(is.numeric(fit2$aiptw_c$cov))
 
-	# univariate reduction with
-	# all SL + stratify
-	fit3 <- drtmle(W = W, A = A, Y = Y,
-               family=gaussian(),
-                  stratify=TRUE,
-                  SL_Q=c("SL.glm","SL.step"),
-                  SL_g=c("SL.glm","SL.step"),
-                  SL_Qr=c("SL.glm","SL.mean"),
-                  SL_gr=c("SL.glm","SL.mean"),
-                  guard=c("Q","g"),
-                  reduction="univariate")
-	expect_true(is.numeric(fit3$gcomp$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$cov))
-	expect_true(is.numeric(fit3$drtmle$est))
-	expect_true(is.numeric(fit3$drtmle$cov))
-	expect_true(is.numeric(fit3$aiptw$est))
-	expect_true(is.numeric(fit3$aiptw$cov))
-	expect_true(is.numeric(fit3$aiptw_c$est))
-	expect_true(is.numeric(fit3$aiptw_c$cov))
+  # univariate reduction with
+  # all SL + stratify
+  fit3 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit3$gcomp$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$cov))
+  expect_true(is.numeric(fit3$drtmle$est))
+  expect_true(is.numeric(fit3$drtmle$cov))
+  expect_true(is.numeric(fit3$aiptw$est))
+  expect_true(is.numeric(fit3$aiptw$cov))
+  expect_true(is.numeric(fit3$aiptw_c$est))
+  expect_true(is.numeric(fit3$aiptw_c$cov))
 
-	#bivariate reduction with
-	# all SL + stratify
-	fit4 <- drtmle(W = W, A = A, Y = Y,
-           family=gaussian(),
-              stratify=TRUE,
-              SL_Q=c("SL.glm","SL.step"),
-              SL_g=c("SL.glm","SL.step"),
-              SL_Qr=c("SL.glm","SL.mean"),
-              SL_gr=c("SL.glm","SL.mean"),
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit4$gcomp$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$cov))
-	expect_true(is.numeric(fit4$drtmle$est))
-	expect_true(is.numeric(fit4$drtmle$cov))
-	expect_true(is.numeric(fit4$aiptw$est))
-	expect_true(is.numeric(fit4$aiptw$cov))
-	expect_true(is.numeric(fit4$aiptw_c$est))
-	expect_true(is.numeric(fit4$aiptw_c$cov))
-	# bivariate reduction with
-	# single SL + stratify
-	fit5 <- drtmle(W = W, A = A, Y = Y,
-           family=gaussian(),
-              stratify=TRUE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit5$gcomp$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$cov))
-	expect_true(is.numeric(fit5$drtmle$est))
-	expect_true(is.numeric(fit5$drtmle$cov))
-	expect_true(is.numeric(fit5$aiptw$est))
-	expect_true(is.numeric(fit5$aiptw$cov))
-	expect_true(is.numeric(fit5$aiptw_c$est))
-	expect_true(is.numeric(fit5$aiptw_c$cov))
-	# univariate reduction with
-	# single SL + stratify
-	fit6 <- drtmle(W = W, A = A, Y = Y,
-           family=gaussian(),
-              stratify=TRUE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate")
-	expect_true(is.numeric(fit6$gcomp$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$cov))
-	expect_true(is.numeric(fit6$drtmle$est))
-	expect_true(is.numeric(fit6$drtmle$cov))
-	expect_true(is.numeric(fit6$aiptw$est))
-	expect_true(is.numeric(fit6$aiptw$cov))
-	expect_true(is.numeric(fit6$aiptw_c$est))
-	expect_true(is.numeric(fit6$aiptw_c$cov))
-
+  # bivariate reduction with
+  # all SL + stratify
+  fit4 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit4$gcomp$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$cov))
+  expect_true(is.numeric(fit4$drtmle$est))
+  expect_true(is.numeric(fit4$drtmle$cov))
+  expect_true(is.numeric(fit4$aiptw$est))
+  expect_true(is.numeric(fit4$aiptw$cov))
+  expect_true(is.numeric(fit4$aiptw_c$est))
+  expect_true(is.numeric(fit4$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify
+  fit5 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit5$gcomp$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$cov))
+  expect_true(is.numeric(fit5$drtmle$est))
+  expect_true(is.numeric(fit5$drtmle$cov))
+  expect_true(is.numeric(fit5$aiptw$est))
+  expect_true(is.numeric(fit5$aiptw$cov))
+  expect_true(is.numeric(fit5$aiptw_c$est))
+  expect_true(is.numeric(fit5$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify
+  fit6 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = TRUE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit6$gcomp$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$cov))
+  expect_true(is.numeric(fit6$drtmle$est))
+  expect_true(is.numeric(fit6$drtmle$cov))
+  expect_true(is.numeric(fit6$aiptw$est))
+  expect_true(is.numeric(fit6$aiptw$cov))
+  expect_true(is.numeric(fit6$aiptw_c$est))
+  expect_true(is.numeric(fit6$aiptw_c$cov))
 })
 
 
-#--------------------------------------------------------------------
+# --------------------------------------------------------------------
 
 test_that("drtmle executes as expected with stratify = FALSE", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- drtmle(W = W, A = A, Y = Y,
-                   family=gaussian(),
-                      stratify=FALSE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="univariate")
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 
-	# bivariate reduction with
-	# all GLMs + stratify
-	fit2 <- drtmle(W = W, A = A, Y = Y,
-                   family=gaussian(),
-                      stratify=FALSE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="bivariate")
+  # bivariate reduction with
+  # all GLMs + stratify
+  fit2 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
 
-	expect_true(is.numeric(fit2$gcomp$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$est))
-	expect_true(is.numeric(fit2$tmle$cov))
-	expect_true(is.numeric(fit2$drtmle$est))
-	expect_true(is.numeric(fit2$drtmle$cov))
-	expect_true(is.numeric(fit2$aiptw$est))
-	expect_true(is.numeric(fit2$aiptw$cov))
-	expect_true(is.numeric(fit2$aiptw_c$est))
-	expect_true(is.numeric(fit2$aiptw_c$cov))
+  expect_true(is.numeric(fit2$gcomp$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$est))
+  expect_true(is.numeric(fit2$tmle$cov))
+  expect_true(is.numeric(fit2$drtmle$est))
+  expect_true(is.numeric(fit2$drtmle$cov))
+  expect_true(is.numeric(fit2$aiptw$est))
+  expect_true(is.numeric(fit2$aiptw$cov))
+  expect_true(is.numeric(fit2$aiptw_c$est))
+  expect_true(is.numeric(fit2$aiptw_c$cov))
 
-	# univariate reduction with
-	# all SL + stratify
-	fit3 <- drtmle(W = W, A = A, Y = Y,
-               family=gaussian(),
-                  stratify=FALSE,
-                  SL_Q=c("SL.glm","SL.step"),
-                  SL_g=c("SL.glm","SL.step"),
-                  SL_Qr=c("SL.glm","SL.mean"),
-                  SL_gr=c("SL.glm","SL.mean"),
-                  guard=c("Q","g"),
-                  reduction="univariate")
-	expect_true(is.numeric(fit3$gcomp$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$est))
-	expect_true(is.numeric(fit3$tmle$cov))
-	expect_true(is.numeric(fit3$drtmle$est))
-	expect_true(is.numeric(fit3$drtmle$cov))
-	expect_true(is.numeric(fit3$aiptw$est))
-	expect_true(is.numeric(fit3$aiptw$cov))
-	expect_true(is.numeric(fit3$aiptw_c$est))
-	expect_true(is.numeric(fit3$aiptw_c$cov))
+  # univariate reduction with
+  # all SL + stratify
+  fit3 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit3$gcomp$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$est))
+  expect_true(is.numeric(fit3$tmle$cov))
+  expect_true(is.numeric(fit3$drtmle$est))
+  expect_true(is.numeric(fit3$drtmle$cov))
+  expect_true(is.numeric(fit3$aiptw$est))
+  expect_true(is.numeric(fit3$aiptw$cov))
+  expect_true(is.numeric(fit3$aiptw_c$est))
+  expect_true(is.numeric(fit3$aiptw_c$cov))
 
-	#bivariate reduction with
-	# all SL + stratify
-	fit4 <- drtmle(W = W, A = A, Y = Y,
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q=c("SL.glm","SL.step"),
-              SL_g=c("SL.glm","SL.step"),
-              SL_Qr=c("SL.glm","SL.mean"),
-              SL_gr=c("SL.glm","SL.mean"),
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit4$gcomp$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$est))
-	expect_true(is.numeric(fit4$tmle$cov))
-	expect_true(is.numeric(fit4$drtmle$est))
-	expect_true(is.numeric(fit4$drtmle$cov))
-	expect_true(is.numeric(fit4$aiptw$est))
-	expect_true(is.numeric(fit4$aiptw$cov))
-	expect_true(is.numeric(fit4$aiptw_c$est))
-	expect_true(is.numeric(fit4$aiptw_c$cov))
-	# bivariate reduction with
-	# single SL + stratify
-	fit5 <- drtmle(W = W, A = A, Y = Y,
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate")
-	expect_true(is.numeric(fit5$gcomp$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$est))
-	expect_true(is.numeric(fit5$tmle$cov))
-	expect_true(is.numeric(fit5$drtmle$est))
-	expect_true(is.numeric(fit5$drtmle$cov))
-	expect_true(is.numeric(fit5$aiptw$est))
-	expect_true(is.numeric(fit5$aiptw$cov))
-	expect_true(is.numeric(fit5$aiptw_c$est))
-	expect_true(is.numeric(fit5$aiptw_c$cov))
-	# univariate reduction with
-	# single SL + stratify
-	fit6 <- drtmle(W = W, A = A, Y = Y,
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate")
-	expect_true(is.numeric(fit6$gcomp$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$est))
-	expect_true(is.numeric(fit6$tmle$cov))
-	expect_true(is.numeric(fit6$drtmle$est))
-	expect_true(is.numeric(fit6$drtmle$cov))
-	expect_true(is.numeric(fit6$aiptw$est))
-	expect_true(is.numeric(fit6$aiptw$cov))
-	expect_true(is.numeric(fit6$aiptw_c$est))
-	expect_true(is.numeric(fit6$aiptw_c$cov))
+  # bivariate reduction with
+  # all SL + stratify
+  fit4 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = c("SL.glm", "SL.step"),
+    SL_g = c("SL.glm", "SL.step"),
+    SL_Qr = c("SL.glm", "SL.mean"),
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit4$gcomp$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$est))
+  expect_true(is.numeric(fit4$tmle$cov))
+  expect_true(is.numeric(fit4$drtmle$est))
+  expect_true(is.numeric(fit4$drtmle$cov))
+  expect_true(is.numeric(fit4$aiptw$est))
+  expect_true(is.numeric(fit4$aiptw$cov))
+  expect_true(is.numeric(fit4$aiptw_c$est))
+  expect_true(is.numeric(fit4$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify
+  fit5 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate"
+  )
+  expect_true(is.numeric(fit5$gcomp$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$est))
+  expect_true(is.numeric(fit5$tmle$cov))
+  expect_true(is.numeric(fit5$drtmle$est))
+  expect_true(is.numeric(fit5$drtmle$cov))
+  expect_true(is.numeric(fit5$aiptw$est))
+  expect_true(is.numeric(fit5$aiptw$cov))
+  expect_true(is.numeric(fit5$aiptw_c$est))
+  expect_true(is.numeric(fit5$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify
+  fit6 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  )
+  expect_true(is.numeric(fit6$gcomp$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$est))
+  expect_true(is.numeric(fit6$tmle$cov))
+  expect_true(is.numeric(fit6$drtmle$est))
+  expect_true(is.numeric(fit6$drtmle$cov))
+  expect_true(is.numeric(fit6$aiptw$est))
+  expect_true(is.numeric(fit6$aiptw$cov))
+  expect_true(is.numeric(fit6$aiptw_c$est))
+  expect_true(is.numeric(fit6$aiptw_c$cov))
 
-	# univariate reduction with
-	# single SL + stratify + Qsteps = 1
-	fit7 <- drtmle(W = W, A = A, Y = Y,
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="univariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit7$gcomp$est))
-	expect_true(is.numeric(fit7$tmle$est))
-	expect_true(is.numeric(fit7$tmle$est))
-	expect_true(is.numeric(fit7$tmle$cov))
-	expect_true(is.numeric(fit7$drtmle$est))
-	expect_true(is.numeric(fit7$drtmle$cov))
-	expect_true(is.numeric(fit7$aiptw$est))
-	expect_true(is.numeric(fit7$aiptw$cov))
-	expect_true(is.numeric(fit7$aiptw_c$est))
-	expect_true(is.numeric(fit7$aiptw_c$cov))
+  # univariate reduction with
+  # single SL + stratify + Qsteps = 1
+  fit7 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "univariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit7$gcomp$est))
+  expect_true(is.numeric(fit7$tmle$est))
+  expect_true(is.numeric(fit7$tmle$est))
+  expect_true(is.numeric(fit7$tmle$cov))
+  expect_true(is.numeric(fit7$drtmle$est))
+  expect_true(is.numeric(fit7$drtmle$cov))
+  expect_true(is.numeric(fit7$aiptw$est))
+  expect_true(is.numeric(fit7$aiptw$cov))
+  expect_true(is.numeric(fit7$aiptw_c$est))
+  expect_true(is.numeric(fit7$aiptw_c$cov))
 
-	# bivariate reduction with
-	# single SL + stratify + Qsteps = 1
-	fit8 <- drtmle(W = W, A = A, Y = Y,
-           family=gaussian(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit8$gcomp$est))
-	expect_true(is.numeric(fit8$tmle$est))
-	expect_true(is.numeric(fit8$tmle$est))
-	expect_true(is.numeric(fit8$tmle$cov))
-	expect_true(is.numeric(fit8$drtmle$est))
-	expect_true(is.numeric(fit8$drtmle$cov))
-	expect_true(is.numeric(fit8$aiptw$est))
-	expect_true(is.numeric(fit8$aiptw$cov))
-	expect_true(is.numeric(fit8$aiptw_c$est))
-	expect_true(is.numeric(fit8$aiptw_c$cov))
+  # bivariate reduction with
+  # single SL + stratify + Qsteps = 1
+  fit8 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = gaussian(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit8$gcomp$est))
+  expect_true(is.numeric(fit8$tmle$est))
+  expect_true(is.numeric(fit8$tmle$est))
+  expect_true(is.numeric(fit8$tmle$cov))
+  expect_true(is.numeric(fit8$drtmle$est))
+  expect_true(is.numeric(fit8$drtmle$cov))
+  expect_true(is.numeric(fit8$aiptw$est))
+  expect_true(is.numeric(fit8$aiptw$cov))
+  expect_true(is.numeric(fit8$aiptw_c$est))
+  expect_true(is.numeric(fit8$aiptw_c$cov))
 
-	# give one a go with family = binomial()
-	# bivariate reduction with
-	# single SL + stratify + Qsteps = 1
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rbinom(n, 1, plogis(W$W1*W$W2*A))
+  # give one a go with family = binomial()
+  # bivariate reduction with
+  # single SL + stratify + Qsteps = 1
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rbinom(n, 1, plogis(W$W1 * W$W2 * A))
 
-	fit9 <- drtmle(W = W, A = A, Y = Y,
-           family=binomial(),
-              stratify=FALSE,
-              SL_Q="SL.glm",
-              SL_g="SL.glm",
-              SL_Qr="SL.glm",
-              SL_gr="SL.glm",
-              guard=c("Q","g"),
-              reduction="bivariate",
-              Qsteps = 1)
-	expect_true(is.numeric(fit9$gcomp$est))
-	expect_true(is.numeric(fit9$tmle$est))
-	expect_true(is.numeric(fit9$tmle$est))
-	expect_true(is.numeric(fit9$tmle$cov))
-	expect_true(is.numeric(fit9$drtmle$est))
-	expect_true(is.numeric(fit9$drtmle$cov))
-	expect_true(is.numeric(fit9$aiptw$est))
-	expect_true(is.numeric(fit9$aiptw$cov))
-	expect_true(is.numeric(fit9$aiptw_c$est))
-	expect_true(is.numeric(fit9$aiptw_c$cov))
-
+  fit9 <- drtmle(
+    W = W, A = A, Y = Y,
+    family = binomial(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm",
+    guard = c("Q", "g"),
+    reduction = "bivariate",
+    Qsteps = 1
+  )
+  expect_true(is.numeric(fit9$gcomp$est))
+  expect_true(is.numeric(fit9$tmle$est))
+  expect_true(is.numeric(fit9$tmle$est))
+  expect_true(is.numeric(fit9$tmle$cov))
+  expect_true(is.numeric(fit9$drtmle$est))
+  expect_true(is.numeric(fit9$drtmle$cov))
+  expect_true(is.numeric(fit9$aiptw$est))
+  expect_true(is.numeric(fit9$aiptw$cov))
+  expect_true(is.numeric(fit9$aiptw_c$est))
+  expect_true(is.numeric(fit9$aiptw_c$cov))
 })

--- a/tests/testthat/test-edge.R
+++ b/tests/testthat/test-edge.R
@@ -5,73 +5,77 @@ library(SuperLearner)
 context("Testing edge cases.")
 
 test_that("drtmle executes as expected when only one value of gn", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	expect_warning(fit1 <- drtmle(W = W, A = A, Y = Y, 
-	              cvFolds = 1, maxIter = 2,
-                  family=gaussian(),
-                  stratify=TRUE,
-                  glm_Q="W1 + W2",
-                  glm_g="1",
-                  glm_Qr="gn",
-                  glm_gr="Qn",
-                  guard=c("Q","g"),
-                  reduction="univariate"))
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  # univariate reduction with
+  # all GLMs + stratify
+  expect_warning(fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    cvFolds = 1, maxIter = 2,
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    glm_g = "1",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  ))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 })
 
 test_that("drtmle executes when glm and SL are specified", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	expect_warning(fit1 <- drtmle(W = W, A = A, Y = Y, 
-	              cvFolds = 1, maxIter = 2,
-                  family=gaussian(),
-                  returnModels = TRUE,
-                  stratify=FALSE,
-                  glm_Q="W1 + W2",
-                  SL_Q = c("SL.glm","SL.mean"),
-                  glm_g="1",
-                  SL_g = c("SL.glm","SL.mean"),
-                  glm_Qr="gn",
-                  SL_Qr = c("SL.glm","SL.mean"),
-                  glm_gr="Qn",
-                  SL_gr = c("SL.glm","SL.mean"),
-                  guard=c("Q","g"),
-                  reduction="univariate"))
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
-	expect_true(class(fit1$QnMod[[1]])=="SuperLearner")
-	expect_true(class(fit1$gnMod[[1]]$A)=="SuperLearner")
-	expect_true(class(fit1$QrnMod[[1]][[1]])=="SuperLearner")
-	expect_true(class(fit1$grnMod[[1]][[1]]$fm1)=="SuperLearner")
-	expect_true(class(fit1$grnMod[[1]][[1]]$fm2)=="SuperLearner")
+  # univariate reduction with
+  # all GLMs + stratify
+  expect_warning(fit1 <- drtmle(
+    W = W, A = A, Y = Y,
+    cvFolds = 1, maxIter = 2,
+    family = gaussian(),
+    returnModels = TRUE,
+    stratify = FALSE,
+    glm_Q = "W1 + W2",
+    SL_Q = c("SL.glm", "SL.mean"),
+    glm_g = "1",
+    SL_g = c("SL.glm", "SL.mean"),
+    glm_Qr = "gn",
+    SL_Qr = c("SL.glm", "SL.mean"),
+    glm_gr = "Qn",
+    SL_gr = c("SL.glm", "SL.mean"),
+    guard = c("Q", "g"),
+    reduction = "univariate"
+  ))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(class(fit1$QnMod[[1]]) == "SuperLearner")
+  expect_true(class(fit1$gnMod[[1]]$A) == "SuperLearner")
+  expect_true(class(fit1$QrnMod[[1]][[1]]) == "SuperLearner")
+  expect_true(class(fit1$grnMod[[1]][[1]]$fm1) == "SuperLearner")
+  expect_true(class(fit1$grnMod[[1]][[1]]$fm2) == "SuperLearner")
 })

--- a/tests/testthat/test-fluctuate.R
+++ b/tests/testthat/test-fluctuate.R
@@ -3,14 +3,14 @@ library(SuperLearner)
 library(np)
 
 context("Testing fail safes in fluctuation")
-test_that("Fail safe kicks in",{
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
-	  n <- length(Y)
-	  tolg <- 1e-3
+test_that("Fail safe kicks in", {
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
+  n <- length(Y)
+  tolg <- 1e-3
   SL_Q <- SL_g <- SL_gr <- NULL
   glm_Q <- glm_g <- "W1 + W2"
   glm_gr <- "Qn"
@@ -24,26 +24,30 @@ test_that("Fail safe kicks in",{
   family <- gaussian()
   reduction <- "univariate"
   # guts of drtmle function
-  if(cvFolds!=1){
-    validRows <- split(sample(1:n), rep(1:cvFolds, length = n))       
-  }else{
+  if (cvFolds != 1) {
+    validRows <- split(sample(1:n), rep(1:cvFolds, length = n))
+  } else {
     validRows <- list(1:n)
   }
-  #-------------------------------
+  # -------------------------------
   # estimate propensity score
-  #-------------------------------
-  if(!parallel){
-    gnOut <- lapply(X = validRows, FUN = estimateG,
-                    A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY,
-                    tolg = tolg, verbose = verbose, stratify = stratify,
-                    returnModels = returnModels,SL_g = SL_g,
-                    glm_g = glm_g, a_0 = a_0)
-  }else{
+  # -------------------------------
+  if (!parallel) {
+    gnOut <- lapply(
+      X = validRows, FUN = estimateG,
+      A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY,
+      tolg = tolg, verbose = verbose, stratify = stratify,
+      returnModels = returnModels, SL_g = SL_g,
+      glm_g = glm_g, a_0 = a_0
+    )
+  } else {
     gnOut <- foreach::foreach(v = 1:cvFolds, .packages = "SuperLearner") %dopar% {
-      estimateG(A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY, 
-                tolg = tolg, verbose = verbose, stratify = stratify,
-                returnModels = returnModels, SL_g = SL_g,
-                glm_g = glm_g, a_0 = a_0, validRows = validRows[[v]])
+      estimateG(
+        A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY,
+        tolg = tolg, verbose = verbose, stratify = stratify,
+        returnModels = returnModels, SL_g = SL_g,
+        glm_g = glm_g, a_0 = a_0, validRows = validRows[[v]]
+      )
     }
   }
 
@@ -51,76 +55,88 @@ test_that("Fail safe kicks in",{
   gnValid <- unlist(gnOut, recursive = FALSE, use.names = FALSE)
   gnUnOrd <- do.call(Map, c(c, gnValid[seq(1, length(gnValid), 2)]))
   gn <- vector(mode = "list", length = length(a_0))
-  for(i in 1:length(a_0)){
+  for (i in 1:length(a_0)) {
     gn[[i]] <- rep(NA, n)
     gn[[i]][unlist(validRows)] <- gnUnOrd[[i]]
   }
 
-  #-------------------------------
+  # -------------------------------
   # estimate outcome regression
-  #-------------------------------
-  if(!parallel){
-    QnOut <- lapply(X = validRows, FUN = estimateQ,
-                    Y = Y, A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY,
-                    verbose = verbose, returnModels = returnModels, 
-                    SL_Q = SL_Q, a_0 = a_0, stratify = stratify, 
-                    glm_Q = glm_Q, family = family)
-  }else{
+  # -------------------------------
+  if (!parallel) {
+    QnOut <- lapply(
+      X = validRows, FUN = estimateQ,
+      Y = Y, A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY,
+      verbose = verbose, returnModels = returnModels,
+      SL_Q = SL_Q, a_0 = a_0, stratify = stratify,
+      glm_Q = glm_Q, family = family
+    )
+  } else {
     QnOut <- foreach::foreach(v = 1:cvFolds, .packages = "SuperLearner") %dopar% {
-      estimateQ(Y = Y, A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY,
-                verbose = verbose, returnModels = returnModels, 
-                SL_Q = SL_Q, a_0 = a_0, glm_Q = glm_Q, family = family, 
-                stratify = stratify, validRows = validRows[[v]])
+      estimateQ(
+        Y = Y, A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY,
+        verbose = verbose, returnModels = returnModels,
+        SL_Q = SL_Q, a_0 = a_0, glm_Q = glm_Q, family = family,
+        stratify = stratify, validRows = validRows[[v]]
+      )
     }
   }
   # re-order predictions
   QnValid <- unlist(QnOut, recursive = FALSE, use.names = FALSE)
-  QnUnOrd <- do.call(Map, c(c, QnValid[seq(1,length(QnValid),2)]))
+  QnUnOrd <- do.call(Map, c(c, QnValid[seq(1, length(QnValid), 2)]))
   Qn <- vector(mode = "list", length = length(a_0))
-  for(i in 1:length(a_0)){
+  for (i in 1:length(a_0)) {
     Qn[[i]] <- rep(NA, n)
     Qn[[i]][unlist(validRows)] <- QnUnOrd[[i]]
   }
 
-  if(!parallel){
-      grnOut <- lapply(X=validRows, FUN = estimategrn,
-                       Y=Y,A=A, W=W, DeltaA = DeltaA, DeltaY = DeltaY, 
-                       tolg=tolg, Qn=Qn, gn=gn, 
-                       glm_gr=glm_gr, SL_gr=SL_gr, a_0=a_0, 
-                       reduction=reduction,returnModels = returnModels)      
-    }else{
-      grnOut <- foreach::foreach(v = 1:cvFolds, .packages = "SuperLearner") %dopar% {
-        estimategrn(Y=Y,A=A, W=W, 
-                    DeltaA = DeltaA, DeltaY = DeltaY,
-                    tolg=tolg, Qn=Qn, gn=gn, 
-                    glm_gr=glm_gr, SL_gr=SL_gr, a_0=a_0, 
-                    reduction=reduction,returnModels = returnModels,
-                    validRows = validRows[[v]])
-      }
+  if (!parallel) {
+    grnOut <- lapply(
+      X = validRows, FUN = estimategrn,
+      Y = Y, A = A, W = W, DeltaA = DeltaA, DeltaY = DeltaY,
+      tolg = tolg, Qn = Qn, gn = gn,
+      glm_gr = glm_gr, SL_gr = SL_gr, a_0 = a_0,
+      reduction = reduction, returnModels = returnModels
+    )
+  } else {
+    grnOut <- foreach::foreach(v = 1:cvFolds, .packages = "SuperLearner") %dopar% {
+      estimategrn(
+        Y = Y, A = A, W = W,
+        DeltaA = DeltaA, DeltaY = DeltaY,
+        tolg = tolg, Qn = Qn, gn = gn,
+        glm_gr = glm_gr, SL_gr = SL_gr, a_0 = a_0,
+        reduction = reduction, returnModels = returnModels,
+        validRows = validRows[[v]]
+      )
     }
-    # re-order predictions
-    grnValid <- unlist(grnOut, recursive = FALSE, use.names = FALSE)
-    grnUnOrd <- do.call(Map, c(rbind, grnValid[seq(1,length(grnValid),2)]))
-    grn <- vector(mode = "list", length = length(a_0))
-    for(i in 1:length(a_0)){
-      grn[[i]] <- data.frame(grn1=rep(NA, n),grn2=rep(NA, n))
-      grn[[i]][unlist(validRows),] <- cbind(grnUnOrd[[i]])
-    }
+  }
+  # re-order predictions
+  grnValid <- unlist(grnOut, recursive = FALSE, use.names = FALSE)
+  grnUnOrd <- do.call(Map, c(rbind, grnValid[seq(1, length(grnValid), 2)]))
+  grn <- vector(mode = "list", length = length(a_0))
+  for (i in 1:length(a_0)) {
+    grn[[i]] <- data.frame(grn1 = rep(NA, n), grn2 = rep(NA, n))
+    grn[[i]][unlist(validRows), ] <- cbind(grnUnOrd[[i]])
+  }
 
 
 
-    #----------------------------------------------
-    # now call fluctuateQ's setting coefTol = 0,
-    # which should trigger fail-safes
-    #----------------------------------------------
-  grbg <- fluctuateQ2(Y, A, W, DeltaY, DeltaA, 
-                      Qn, gn, grn, a_0, reduction, coefTol=0)
-  # set tolerance threshold 
+  # ----------------------------------------------
+  # now call fluctuateQ's setting coefTol = 0,
+  # which should trigger fail-safes
+  # ----------------------------------------------
+  grbg <- fluctuateQ2(
+    Y, A, W, DeltaY, DeltaA,
+    Qn, gn, grn, a_0, reduction, coefTol = 0
+  )
+  # set tolerance threshold
   tol <- 1e-4
-  # should just return Qn 
+  # should just return Qn
   expect_true(all(grbg[[1]]$est - Qn[[1]] < tol))
 
-  grbg2 <- fluctuateQ(Y, A, W, DeltaY, DeltaA, 
-                      Qn, gn, grn, a_0, reduction, coefTol=0)
+  grbg2 <- fluctuateQ(
+    Y, A, W, DeltaY, DeltaA,
+    Qn, gn, grn, a_0, reduction, coefTol = 0
+  )
   expect_true(all(grbg2[[1]]$est - Qn[[1]] < tol))
 })

--- a/tests/testthat/test-multileveltrt.R
+++ b/tests/testthat/test-multileveltrt.R
@@ -5,130 +5,136 @@ library(SuperLearner)
 context("Testing drtmle function with > 2 treatment levels")
 
 test_that("drtmle executes as expected with multiple treatment levels", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2)) + rbinom(n,1,plogis(W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2)) + rbinom(n, 1, plogis(W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- drtmle(W = W, A = A, Y = Y, a_0=c(0,1,2),
-                   family=gaussian(),
-                      stratify=TRUE,
-                      glm_Q="W1 + W2",
-                      glm_g="W1 + W2",
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="univariate",
-                      returnModels = TRUE)
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y, a_0 = c(0, 1, 2),
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    glm_g = "W1 + W2",
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate",
+    returnModels = TRUE
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 
-	# check ci works
-	ci <- ci(fit1)
-	expect_true(length(fit1$drtmle$est)==3)
-	# check contrasts work
-	ci2 <- ci(fit1, contrast = c(1,-1,0))
-	expect_true(row.names(ci2$drtmle) == "E[Y(0)]-E[Y(1)]")
-	ci3 <- ci(fit1, contrast = c(1,0,-1))
-	expect_true(row.names(ci3$drtmle) == "E[Y(0)]-E[Y(2)]")
+  # check ci works
+  ci <- ci(fit1)
+  expect_true(length(fit1$drtmle$est) == 3)
+  # check contrasts work
+  ci2 <- ci(fit1, contrast = c(1, -1, 0))
+  expect_true(row.names(ci2$drtmle) == "E[Y(0)]-E[Y(1)]")
+  ci3 <- ci(fit1, contrast = c(1, 0, -1))
+  expect_true(row.names(ci3$drtmle) == "E[Y(0)]-E[Y(2)]")
 
 
-	# same thing but with super learner for g
-	fit1 <- drtmle(W = W, A = A, Y = Y, a_0=c(0,1,2),
-                   family=gaussian(),
-                      stratify=TRUE,
-                      glm_Q="W1 + W2",
-                      SL_g=c("SL.step","SL.glm"),
-                      glm_Qr="gn",
-                      glm_gr="Qn",
-                      guard=c("Q","g"),
-                      reduction="univariate",
-                      returnModels = TRUE)
+  # same thing but with super learner for g
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y, a_0 = c(0, 1, 2),
+    family = gaussian(),
+    stratify = TRUE,
+    glm_Q = "W1 + W2",
+    SL_g = c("SL.step", "SL.glm"),
+    glm_Qr = "gn",
+    glm_gr = "Qn",
+    guard = c("Q", "g"),
+    reduction = "univariate",
+    returnModels = TRUE
+  )
 
-	expect_true(is.numeric(fit1$gcomp$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$est))
-	expect_true(is.numeric(fit1$tmle$cov))
-	expect_true(is.numeric(fit1$drtmle$est))
-	expect_true(is.numeric(fit1$drtmle$cov))
-	expect_true(is.numeric(fit1$aiptw$est))
-	expect_true(is.numeric(fit1$aiptw$cov))
-	expect_true(is.numeric(fit1$aiptw_c$est))
-	expect_true(is.numeric(fit1$aiptw_c$cov))
+  expect_true(is.numeric(fit1$gcomp$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$est))
+  expect_true(is.numeric(fit1$tmle$cov))
+  expect_true(is.numeric(fit1$drtmle$est))
+  expect_true(is.numeric(fit1$drtmle$cov))
+  expect_true(is.numeric(fit1$aiptw$est))
+  expect_true(is.numeric(fit1$aiptw$cov))
+  expect_true(is.numeric(fit1$aiptw_c$est))
+  expect_true(is.numeric(fit1$aiptw_c$cov))
 
-	# check ci works
-	ci <- ci(fit1)
-	expect_true(length(fit1$drtmle$est)==3)
-	# check contrasts work
-	ci2 <- ci(fit1, contrast = c(1,-1,0))
-	expect_true(row.names(ci2$drtmle) == "E[Y(0)]-E[Y(1)]")
-	ci3 <- ci(fit1, contrast = c(1,0,-1))
-	expect_true(row.names(ci3$drtmle) == "E[Y(0)]-E[Y(2)]")
+  # check ci works
+  ci <- ci(fit1)
+  expect_true(length(fit1$drtmle$est) == 3)
+  # check contrasts work
+  ci2 <- ci(fit1, contrast = c(1, -1, 0))
+  expect_true(row.names(ci2$drtmle) == "E[Y(0)]-E[Y(1)]")
+  ci3 <- ci(fit1, contrast = c(1, 0, -1))
+  expect_true(row.names(ci3$drtmle) == "E[Y(0)]-E[Y(2)]")
 })
 
 
 test_that("adaptive_iptw executes as expected with multiple treatment levels", {
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2)) + rbinom(n,1,plogis(W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2)) + rbinom(n, 1, plogis(W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y, a_0=c(0,1,2),
-                      glm_g="W1 + W2",
-                      returnModels = TRUE,
-                      glm_Qr="gn")
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y, a_0 = c(0, 1, 2),
+    glm_g = "W1 + W2",
+    returnModels = TRUE,
+    glm_Qr = "gn"
+  )
 
-	expect_true(is.numeric(fit1$iptw$est))
-	expect_true(is.numeric(fit1$iptw_tmle$est))
-	expect_true(is.numeric(fit1$iptw_os$est))
-	expect_true(is.numeric(fit1$iptw_os$cov))
-	expect_true(is.numeric(fit1$iptw_tmle$cov))
-	# check ci works
-	ci <- ci(fit1)
-	expect_true(length(fit1$iptw_tmle$est)==3)
-	# check contrasts work
-	ci2 <- ci(fit1, contrast = c(1,-1,0))
-	expect_true(row.names(ci2$iptw_tmle) == "E[Y(0)]-E[Y(1)]")
-	ci3 <- ci(fit1, contrast = c(1,0,-1))
-	expect_true(row.names(ci3$iptw_tmle) == "E[Y(0)]-E[Y(2)]")
-
-
-	# same thing but with super learner for g
-	# univariate reduction with
-	# all GLMs + stratify
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y, a_0=c(0,1,2),
-                      SL_g=c("SL.step","SL.step.interaction"),
-                      returnModels = TRUE,
-                      glm_Qr="gn")
-
-	expect_true(is.numeric(fit1$iptw$est))
-	expect_true(is.numeric(fit1$iptw_tmle$est))
-	expect_true(is.numeric(fit1$iptw_os$est))
-	expect_true(is.numeric(fit1$iptw_os$cov))
-	expect_true(is.numeric(fit1$iptw_tmle$cov))
-	# check ci works
-	ci <- ci(fit1)
-	expect_true(length(fit1$iptw_tmle$est)==3)
-	# check contrasts work
-	ci2 <- ci(fit1, contrast = c(1,-1,0))
-	expect_true(row.names(ci2$iptw_tmle) == "E[Y(0)]-E[Y(1)]")
-	ci3 <- ci(fit1, contrast = c(1,0,-1))
-	expect_true(row.names(ci3$iptw_tmle) == "E[Y(0)]-E[Y(2)]")
+  expect_true(is.numeric(fit1$iptw$est))
+  expect_true(is.numeric(fit1$iptw_tmle$est))
+  expect_true(is.numeric(fit1$iptw_os$est))
+  expect_true(is.numeric(fit1$iptw_os$cov))
+  expect_true(is.numeric(fit1$iptw_tmle$cov))
+  # check ci works
+  ci <- ci(fit1)
+  expect_true(length(fit1$iptw_tmle$est) == 3)
+  # check contrasts work
+  ci2 <- ci(fit1, contrast = c(1, -1, 0))
+  expect_true(row.names(ci2$iptw_tmle) == "E[Y(0)]-E[Y(1)]")
+  ci3 <- ci(fit1, contrast = c(1, 0, -1))
+  expect_true(row.names(ci3$iptw_tmle) == "E[Y(0)]-E[Y(2)]")
 
 
+  # same thing but with super learner for g
+  # univariate reduction with
+  # all GLMs + stratify
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y, a_0 = c(0, 1, 2),
+    SL_g = c("SL.step", "SL.step.interaction"),
+    returnModels = TRUE,
+    glm_Qr = "gn"
+  )
+
+  expect_true(is.numeric(fit1$iptw$est))
+  expect_true(is.numeric(fit1$iptw_tmle$est))
+  expect_true(is.numeric(fit1$iptw_os$est))
+  expect_true(is.numeric(fit1$iptw_os$cov))
+  expect_true(is.numeric(fit1$iptw_tmle$cov))
+  # check ci works
+  ci <- ci(fit1)
+  expect_true(length(fit1$iptw_tmle$est) == 3)
+  # check contrasts work
+  ci2 <- ci(fit1, contrast = c(1, -1, 0))
+  expect_true(row.names(ci2$iptw_tmle) == "E[Y(0)]-E[Y(1)]")
+  ci3 <- ci(fit1, contrast = c(1, 0, -1))
+  expect_true(row.names(ci3$iptw_tmle) == "E[Y(0)]-E[Y(2)]")
 })

--- a/tests/testthat/test-npreg.R
+++ b/tests/testthat/test-npreg.R
@@ -4,21 +4,21 @@ library(np)
 
 context("Testing super learner wrappers")
 
-test_that("SL.npreg works as expected",{
-	set.seed(1234)
-	n <- 100
-	X <- data.frame(X1 = rnorm(n))
-	Y <- rnorm(n,X$X1,1)
-	fit <- SL.npreg(Y=Y,X=X,newX=X,
-	                obsWeights = rep(1,n))
-	expect_true(is.numeric(fit$pred))
-	expect_true(all(!is.na(fit$pred)))
-	expect_true(class(fit$fit)=="SL.npreg")
-	# test predict function
-	newX <- data.frame(X1=seq(-1,1,length=10))
-	pred <- predict(fit$fit, newdata=newX)
-	expect_true(is.numeric(pred))
-	expect_true(all(!is.na(pred)))
+test_that("SL.npreg works as expected", {
+  set.seed(1234)
+  n <- 100
+  X <- data.frame(X1 = rnorm(n))
+  Y <- rnorm(n, X$X1, 1)
+  fit <- SL.npreg(
+    Y = Y, X = X, newX = X,
+    obsWeights = rep(1, n)
+  )
+  expect_true(is.numeric(fit$pred))
+  expect_true(all(!is.na(fit$pred)))
+  expect_true(class(fit$fit) == "SL.npreg")
+  # test predict function
+  newX <- data.frame(X1 = seq(-1, 1, length = 10))
+  pred <- predict(fit$fit, newdata = newX)
+  expect_true(is.numeric(pred))
+  expect_true(all(!is.na(pred)))
 })
-
-

--- a/tests/testthat/test-tests.R
+++ b/tests/testthat/test-tests.R
@@ -2,121 +2,145 @@ library(drtmle)
 library(SuperLearner)
 
 context("Testing wald_test.drtmle method ")
-test_that("wald_test.drtmle works as expected",{
-	# simulate data
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rbinom(n, 1, plogis(W$W1*W$W2*A))
-	# fit a drtmle
-	fit1 <- drtmle(W = W, A = A, Y = Y, a_0 = c(1,0),
-					  family=binomial(),
-	               stratify=FALSE,
-	               SL_Q="SL.glm",
-	               SL_g="SL.glm",
-	               SL_Qr="SL.glm",
-	               SL_gr="SL.glm")
+test_that("wald_test.drtmle works as expected", {
+  # simulate data
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rbinom(n, 1, plogis(W$W1 * W$W2 * A))
+  # fit a drtmle
+  fit1 <- drtmle(
+    W = W, A = A, Y = Y, a_0 = c(1, 0),
+    family = binomial(),
+    stratify = FALSE,
+    SL_Q = "SL.glm",
+    SL_g = "SL.glm",
+    SL_Qr = "SL.glm",
+    SL_gr = "SL.glm"
+  )
 
-	# get test for each mean for only drtmle
-	tmp <- wald_test(fit1)
-	# correct class
-	expect_true(class(tmp)=="wald_test.drtmle")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get test for each mean for only drtmle
+  tmp <- wald_test(fit1)
+  # correct class
+  expect_true(class(tmp) == "wald_test.drtmle")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 
-	# get test for each mean for drtmle and tmle
-	tmp <- wald_test(fit1, est = c("drtmle","tmle","aiptw","aiptw_c","gcomp"))
+  # get test for each mean for drtmle and tmle
+  tmp <- wald_test(fit1, est = c("drtmle", "tmle", "aiptw", "aiptw_c", "gcomp"))
 
-	# correct class
-	expect_true(class(tmp)=="wald_test.drtmle")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
-	expect_true(length(tmp) == 5)
-	expect_true(all(names(tmp) == c("drtmle","tmle","aiptw","aiptw_c","gcomp")))
-	expect_true(nrow(tmp$drtmle) == 2)
-	expect_true(nrow(tmp$tmle) == 2)
+  # correct class
+  expect_true(class(tmp) == "wald_test.drtmle")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
+  expect_true(length(tmp) == 5)
+  expect_true(all(names(tmp) == c("drtmle", "tmle", "aiptw", "aiptw_c", "gcomp")))
+  expect_true(nrow(tmp$drtmle) == 2)
+  expect_true(nrow(tmp$tmle) == 2)
 
-	# get test for ATE
-	tmp <- wald_test(fit1, contrast = c(1,-1))
-	# correct class
-	expect_true(class(tmp)=="wald_test.drtmle")
-	# correct row name
-	expect_true(row.names(tmp$drtmle) == "H0:E[Y(1)]-E[Y(0)]=0")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get test for ATE
+  tmp <- wald_test(fit1, contrast = c(1, -1))
+  # correct class
+  expect_true(class(tmp) == "wald_test.drtmle")
+  # correct row name
+  expect_true(row.names(tmp$drtmle) == "H0:E[Y(1)]-E[Y(0)]=0")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 
-	# throws error if crazy contrast is put in 
-	expect_error(wald_test(fit1, contrast = c(10214,NA)))
+  # throws error if crazy contrast is put in
+  expect_error(wald_test(fit1, contrast = c(10214, NA)))
 
-	# get test for risk ratio 
-	# by inputting own contrast function
-	# this computes CI on log scale and back transforms
-	myContrast <- list(f = function(eff){ log(eff) },
-	                   f_inv = function(eff){ exp(eff) },
-	                   h = function(est){ est[1]/est[2] },
-	                   fh_grad =  function(est){ c(1/est[1],-1/est[2]) })
-	tmp <- wald_test(fit1, contrast = myContrast, null = 1)
-	expect_true(class(tmp)=="wald_test.drtmle")
-	expect_true(row.names(tmp$drtmle) == "H0: user contrast = 1")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get test for risk ratio
+  # by inputting own contrast function
+  # this computes CI on log scale and back transforms
+  myContrast <- list(
+    f = function(eff) {
+      log(eff)
+    },
+    f_inv = function(eff) {
+      exp(eff)
+    },
+    h = function(est) {
+      est[1] / est[2]
+    },
+    fh_grad = function(est) {
+      c(1 / est[1], -1 / est[2])
+    }
+  )
+  tmp <- wald_test(fit1, contrast = myContrast, null = 1)
+  expect_true(class(tmp) == "wald_test.drtmle")
+  expect_true(row.names(tmp$drtmle) == "H0: user contrast = 1")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 })
 
 context("Testing ci.adaptive_iptw method ")
-test_that("wald_test.adaptive_iptw works as expected",{
-	# simulate data
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rbinom(n, 1, plogis(W$W1*W$W2*A))
-	# fit a adaptive_iptw
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y, a_0 = c(1,0),
-	               SL_g=c("SL.glm","SL.mean","SL.step"),
-	               SL_Qr="SL.glm")
+test_that("wald_test.adaptive_iptw works as expected", {
+  # simulate data
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rbinom(n, 1, plogis(W$W1 * W$W2 * A))
+  # fit a adaptive_iptw
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y, a_0 = c(1, 0),
+    SL_g = c("SL.glm", "SL.mean", "SL.step"),
+    SL_Qr = "SL.glm"
+  )
 
-	# get test for each mean for only drtmle
-	tmp <- wald_test(fit1)
-	# correct class
-	expect_true(class(tmp)=="wald_test.adaptive_iptw")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get test for each mean for only drtmle
+  tmp <- wald_test(fit1)
+  # correct class
+  expect_true(class(tmp) == "wald_test.adaptive_iptw")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 
-	# get test for each mean for drtmle and tmle
-	tmp <- wald_test(fit1, est = c("iptw_tmle","iptw_os"))
+  # get test for each mean for drtmle and tmle
+  tmp <- wald_test(fit1, est = c("iptw_tmle", "iptw_os"))
 
-	# correct class
-	expect_true(class(tmp)=="wald_test.adaptive_iptw")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
-	expect_true(length(tmp) == 2)
-	expect_true(all(names(tmp) == c("iptw_tmle","iptw_os")))
-	expect_true(nrow(tmp$iptw_tmle) == 2)
-	expect_true(nrow(tmp$iptw_os) == 2)
+  # correct class
+  expect_true(class(tmp) == "wald_test.adaptive_iptw")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
+  expect_true(length(tmp) == 2)
+  expect_true(all(names(tmp) == c("iptw_tmle", "iptw_os")))
+  expect_true(nrow(tmp$iptw_tmle) == 2)
+  expect_true(nrow(tmp$iptw_os) == 2)
 
-	# get test for ATE
-	tmp <- wald_test(fit1, contrast = c(1,-1))
-	# correct class
-	expect_true(class(tmp)=="wald_test.adaptive_iptw")
-	# correct row name
-	expect_true(row.names(tmp$iptw_tmle) == "H0:E[Y(1)]-E[Y(0)]=0")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get test for ATE
+  tmp <- wald_test(fit1, contrast = c(1, -1))
+  # correct class
+  expect_true(class(tmp) == "wald_test.adaptive_iptw")
+  # correct row name
+  expect_true(row.names(tmp$iptw_tmle) == "H0:E[Y(1)]-E[Y(0)]=0")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 
-	# throws error if crazy contrast is put in 
-	expect_error(wald_test(fit1, contrast = c(10214,NA)))
+  # throws error if crazy contrast is put in
+  expect_error(wald_test(fit1, contrast = c(10214, NA)))
 
-	# get test for risk ratio 
-	# by inputting own contrast function
-	# this computes CI on log scale and back transforms
-	myContrast <- list(f = function(eff){ log(eff) },
-	                   f_inv = function(eff){ exp(eff) },
-	                   h = function(est){ est[1]/est[2] },
-	                   fh_grad =  function(est){ c(1/est[1],-1/est[2]) })
-	tmp <- wald_test(fit1, contrast = myContrast, null = 1)
-	expect_true(class(tmp)=="wald_test.adaptive_iptw")
-	expect_true(row.names(tmp$iptw_tmle) == "H0: user contrast = 1")
-	# no NAs
-	expect_true(sum(is.na(unlist(tmp)))==0)
+  # get test for risk ratio
+  # by inputting own contrast function
+  # this computes CI on log scale and back transforms
+  myContrast <- list(
+    f = function(eff) {
+      log(eff)
+    },
+    f_inv = function(eff) {
+      exp(eff)
+    },
+    h = function(est) {
+      est[1] / est[2]
+    },
+    fh_grad = function(est) {
+      c(1 / est[1], -1 / est[2])
+    }
+  )
+  tmp <- wald_test(fit1, contrast = myContrast, null = 1)
+  expect_true(class(tmp) == "wald_test.adaptive_iptw")
+  expect_true(row.names(tmp$iptw_tmle) == "H0: user contrast = 1")
+  # no NAs
+  expect_true(sum(is.na(unlist(tmp))) == 0)
 })

--- a/tests/testthat/testthat-adaptive_iptw.R
+++ b/tests/testthat/testthat-adaptive_iptw.R
@@ -5,22 +5,24 @@ library(testthat)
 # TO DO: Add tests for multiple treatment levels
 context("Testing adaptive_iptw works with cv")
 
-test_that("adaptive_iptw works as expected with cv",{
-	set.seed(123456)
-	n <- 200
-	W <- data.frame(W1 = runif(n), W2 = rnorm(n))
-	A <- rbinom(n,1,plogis(W$W1 - W$W2))
-	Y <- rnorm(n, W$W1*W$W2*A, 2)
+test_that("adaptive_iptw works as expected with cv", {
+  set.seed(123456)
+  n <- 200
+  W <- data.frame(W1 = runif(n), W2 = rnorm(n))
+  A <- rbinom(n, 1, plogis(W$W1 - W$W2))
+  Y <- rnorm(n, W$W1 * W$W2 * A, 2)
 
-	fit1 <- adaptive_iptw(W = W, A = A, Y = Y,
-					cvFolds = 2,  
-	               a_0 = c(0,1),
-                  glm_g="W1 + W2",
-                  glm_Qr="gn")
-	expect_true(all(!is.na(fit1$iptw_tmle$est)))
-	expect_true(all(!is.na(fit1$iptw_tmle$cov)))
-	expect_true(all(!is.na(fit1$iptw_os$est)))
-	expect_true(all(!is.na(fit1$iptw_os$cov)))
-	expect_true(all(!is.na(fit1$iptw$est)))
-	expect_true(class(fit1)=="adaptive_iptw")
-})	
+  fit1 <- adaptive_iptw(
+    W = W, A = A, Y = Y,
+    cvFolds = 2,
+    a_0 = c(0, 1),
+    glm_g = "W1 + W2",
+    glm_Qr = "gn"
+  )
+  expect_true(all(!is.na(fit1$iptw_tmle$est)))
+  expect_true(all(!is.na(fit1$iptw_tmle$cov)))
+  expect_true(all(!is.na(fit1$iptw_os$est)))
+  expect_true(all(!is.na(fit1$iptw_os$cov)))
+  expect_true(all(!is.na(fit1$iptw$est)))
+  expect_true(class(fit1) == "adaptive_iptw")
+})


### PR DESCRIPTION
This PR fixes a bug in R-check that comes about from not explicitly invoking any of the imported functions from the package `future.batchtools`.

* Each of the few HPC backends supported by `future.batchtools` are explicitly called when the correct string is provided as input.
* __misc:__ The `Makefile` was slightly revised to add a few new recipes, and `style_pkg` from the handy [`styler` package](http://styler.r-lib.org/) was used to re-style the code base to [tidyverse style](http://style.tidyverse.org/); also add ORCID info for authors/contributors.
  
  