### PR TITLE
nnloglik_mod: ensure modZ remains a matrix after dropping duplicate columns

### DIFF
--- a/R/method_fixes.R
+++ b/R/method_fixes.R
@@ -102,7 +102,7 @@ method.CC_nloglik_mod <- function() {
         "Algorithm ", colDup,
         " is duplicated. Setting weight to 0."
       ))
-      modZ <- modZ[, -colDup]
+      modZ <- modZ[, -colDup, drop = FALSE]
     }
     modlogitZ <- SuperLearner::trimLogit(modZ, control$trimLogit)
     logitZ <- SuperLearner::trimLogit(Z, control$trimLogit)


### PR DESCRIPTION
Hello,

Here is a quick fix to CC_nnloglik_mod to add a drop = FALSE when removing duplicate columns. I ran into the issue while testing a placeholder library with only two learners, and it ends up causing an error when ncol(modZ) is called while creating the bounds.

Thanks,
Chris