### PR TITLE
CRAN recommendation: add foreach to Suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Suggests:
     quadprog,
     nloptr,
     parallel,
-    snow
+    snow,
+    foreach
 License: MIT + file LICENSE
 URL: https://github.com/benkeser/drtmle
 BugReports: https://github.com/benkeser/drtmle/issues

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,6 @@ check:
 checkfast:
 	Rscript -e "devtools::check(build_args = '--no-build-vignettes')"
 
-bioc:
-	Rscript -e "BiocCheck::BiocCheck('.')"
-
 test:
 	Rscript -e "devtools::test()"
 


### PR DESCRIPTION
The purpose of this PR is to address a minor problem pointed out by the CRAN team --- although the parallelization package `foreach` is used with a call to `library()` in a few of the unit test files in this package, `foreach` itself is not listed in the `Suggests` field of the `DESCRIPTION` file. This PR amends that omission.